### PR TITLE
[PROPOSAL] Allow the client to pass a callback that receives arguments Instructor sends to LLM providers

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -64,6 +64,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> Awaitable[T]:
         ...
@@ -76,6 +78,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> T:
         ...
@@ -88,8 +92,11 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
-    ) -> Awaitable[Any]: ...
+    ) -> Awaitable[Any]:
+        ...
 
     @overload
     def create(
@@ -99,8 +106,11 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
-    ) -> Any: ...
+    ) -> Any:
+        ...
 
     def create(
         self,
@@ -109,6 +119,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> T | Any | Awaitable[T] | Awaitable[Any]:
         kwargs = self.handle_kwargs(kwargs)
@@ -119,6 +131,7 @@ class Instructor:
             max_retries=max_retries,
             validation_context=validation_context,
             strict=strict,
+            provider_args_callback=provider_args_callback,
             **kwargs,
         )
 
@@ -223,6 +236,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> Awaitable[tuple[T, Any]]:
         ...
@@ -235,6 +250,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> tuple[T, Any]:
         ...
@@ -246,6 +263,8 @@ class Instructor:
         max_retries: int = 3,
         validation_context: dict[str, Any] | None = None,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None]
+        | None = None,
         **kwargs: Any,
     ) -> tuple[T, Any] | Awaitable[tuple[T, Any]]:
         kwargs = self.handle_kwargs(kwargs)
@@ -255,6 +274,7 @@ class Instructor:
             max_retries=max_retries,
             validation_context=validation_context,
             strict=strict,
+            provider_args_callback=provider_args_callback,
             **kwargs,
         )
         return model, model._raw_response

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -1,12 +1,6 @@
 # type: ignore[all]
 from functools import wraps
-from typing import (
-    Callable,
-    Protocol,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Callable, Protocol, TypeVar, Union, overload, Any
 from collections.abc import Awaitable
 from typing_extensions import ParamSpec
 
@@ -35,7 +29,8 @@ class InstructorChatCompletionCreate(Protocol):
         max_retries: int = 1,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
-    ) -> T_Model: ...
+    ) -> T_Model:
+        ...
 
 
 class AsyncInstructorChatCompletionCreate(Protocol):
@@ -46,35 +41,40 @@ class AsyncInstructorChatCompletionCreate(Protocol):
         max_retries: int = 1,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
-    ) -> T_Model: ...
+    ) -> T_Model:
+        ...
 
 
 @overload
 def patch(
     client: OpenAI,
     mode: Mode = Mode.TOOLS,
-) -> OpenAI: ...
+) -> OpenAI:
+    ...
 
 
 @overload
 def patch(
     client: AsyncOpenAI,
     mode: Mode = Mode.TOOLS,
-) -> AsyncOpenAI: ...
+) -> AsyncOpenAI:
+    ...
 
 
 @overload
 def patch(
     create: Callable[T_ParamSpec, T_Retval],
     mode: Mode = Mode.TOOLS,
-) -> InstructorChatCompletionCreate: ...
+) -> InstructorChatCompletionCreate:
+    ...
 
 
 @overload
 def patch(
     create: Awaitable[T_Retval],
     mode: Mode = Mode.TOOLS,
-) -> InstructorChatCompletionCreate: ...
+) -> InstructorChatCompletionCreate:
+    ...
 
 
 def patch(
@@ -110,6 +110,9 @@ def patch(
         validation_context: dict = None,
         max_retries: int = 1,
         strict: bool = True,
+        provider_args_callback: Callable[
+            [list[Any], dict[str, Any]], Awaitable[None]
+        ] = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -124,6 +127,7 @@ def patch(
             args=args,
             kwargs=new_kwargs,
             strict=strict,
+            provider_args_callback=provider_args_callback,
             mode=mode,
         )
         return response
@@ -134,6 +138,7 @@ def patch(
         validation_context: dict = None,
         max_retries: int = 1,
         strict: bool = True,
+        provider_args_callback: Callable[[list[Any], dict[str, Any]], None] = None,
         *args: T_ParamSpec.args,
         **kwargs: T_ParamSpec.kwargs,
     ) -> T_Model:
@@ -147,6 +152,7 @@ def patch(
             max_retries=max_retries,
             args=args,
             strict=strict,
+            provider_args_callback=provider_args_callback,
             kwargs=new_kwargs,
             mode=mode,
         )

--- a/instructor/retry.py
+++ b/instructor/retry.py
@@ -137,6 +137,7 @@ def retry_sync(
     max_retries: int | Retrying = 1,
     strict: bool | None = None,
     mode: Mode = Mode.TOOLS,
+    provider_args_callback: Callable[[list[Any], dict[str, Any]], None] | None = None,
 ) -> T_Model:
     total_usage = CompletionUsage(completion_tokens=0, prompt_tokens=0, total_tokens=0)
     if mode in {Mode.ANTHROPIC_TOOLS, Mode.ANTHROPIC_JSON}:
@@ -158,6 +159,7 @@ def retry_sync(
         for attempt in max_retries:
             with attempt:
                 try:
+                    provider_args_callback(args, kwargs)
                     response = func(*args, **kwargs)
                     stream = kwargs.get("stream", False)
                     response = update_total_usage(response, total_usage)


### PR DESCRIPTION
Instructor doesn't expose an easy way to see or use the raw arguments that Instructor finally sends over to a language model: #907, #767, https://github.com/jxnl/instructor/issues/888#issuecomment-2262366959)

This PR is a sketch of an idea that solves this problem in a way that:

- Allows `instructor` clients to receive these arguments and do whatever they want with them, every time `instructor` calls out to an language model provider (including every retry).
- Doesn't require first-class integrations between a third party logging service and an underlying client for logging.

It does this by allowing users to pass in a callback, like so:

```python
def log_llm_args(args: list[Any], kwargs: dict[str, Any]):
    logger.info(f"LLM args: {args}")
    logger.info(f"LLM kwargs: {kwargs}")


def main():
    client = instructor.from_anthropic(
        Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
    )

    user_info = client.chat.completions.create(
        model="claude-3-haiku-20240307",
        response_model=UserInfo,
        messages=[
            {
                "role": "system",
                "content": "You are an expert at extracting information about users from sentences.",
            },
            {"role": "user", "content": "John Doe is 30 years old."},
        ],
        max_tokens=4096,
        max_retries=3,
        provider_args_callback=log_llm_args, # This will get called every time `instructor` calls out to an LLM provider with the same args/kwargs.
    )

    print(user_info.name)
    print(user_info.age)


if __name__ == "__main__":
    main()
```

The code below is a working implementation for Anthropic's synchronous client, that applies to `create` and `create_with_completion`.

This is more-or-less what it'd look like for other providers if this is something you want to do.

An extension we could add is to provide an `attempt_num` and intermediate completions received before retries, which might be helpful for some use cases.

I'm personally keen to have this kind of functionality in `instructor`, some way or another (vs. just logging)

If the strategy below works for you, I can submit a PR that works with sync/async and the major providers (OpenAI/Anthropic/Google).

If not, would love to know either:

a) This is not a problem you care to solve.
b) You also want to solve it, but differently.

Thanks!
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ed5aeb98ef30dba0cc0a5c1ddc58d09eb337aa9b  | 
|--------|--------|

### Summary:
Introduced `provider_args_callback` to log or handle arguments passed to language model providers in `instructor`.

**Key points**:
- Added `provider_args_callback` parameter to `create`, `create_with_completion`, and other relevant methods in `instructor/client.py`.
- Updated `patch` function in `instructor/patch.py` to handle `provider_args_callback`.
- Modified `retry_sync` and `retry_async` functions in `instructor/retry.py` to call `provider_args_callback` with request arguments and keyword arguments.
- Allows clients to pass a callback to log or handle arguments sent to language model providers.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->