### PR TITLE
fix: update gemini's `safety_settings`

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -347,22 +347,19 @@ def update_gemini_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     # minimize gemini safety related errors - model is highly prone to false alarms
     from google.generativeai.types import HarmCategory, HarmBlockThreshold  # type: ignore
 
-    minimum_safety_settings = {
+    kwargs["safety_settings"] = kwargs.get("safety_settings", {})
+
+    fallback_safety_settings = {
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_ONLY_HIGH,
         HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_ONLY_HIGH,
         HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH,
     }
 
-    existing_safety_settings = kwargs.get("safety_settings", {})
-
-    # Start with existing settings to preserve any additional categories
-    kwargs["safety_settings"] = existing_safety_settings.copy()
-
-    # Update or add defaults, respecting stricter existing settings
-    for category, minimum_threshold in minimum_safety_settings.items():
-        existing_threshold = kwargs["safety_settings"].get(category)
-        if existing_threshold is None or existing_threshold < minimum_threshold:
-            kwargs["safety_settings"][category] = minimum_threshold
+    # Update or add fallback settings, respecting stricter existing ones
+    for category, fallback_threshold in fallback_safety_settings.items():
+        current_threshold = kwargs["safety_settings"].get(category)
+        if current_threshold is None or current_threshold < fallback_threshold:
+            kwargs["safety_settings"][category] = fallback_threshold
 
     return kwargs
 


### PR DESCRIPTION
Addressing the issue where instructor's "required" `safety_settings` are overriding user-provided or pre-existing settings in the Gemini model configuration.

These settings are applied unconditionally. The updates ensure that default settings are applied only if they represent a more restrictive threshold than the existing setting for a given harm category.

This preserves any pre-existing settings that have:
* A higher (less restrictive) threshold (e.g. `BLOCK_NONE` compared to `BLOCK_ONLY_HIGH`).
* Additional categories not included in the default settings (e.g. `HARM_CATEGORY_SEXUALLY_EXPLICIT`).

This change ensures that user-specified safety configurations are respected while still providing required settings levels when none are provided.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `update_gemini_kwargs` in `instructor/utils.py` to respect user-provided `safety_settings` by applying defaults only if more restrictive.
> 
>   - **Behavior**:
>     - Updates `update_gemini_kwargs` in `instructor/utils.py` to apply default `safety_settings` only if they are more restrictive than existing settings.
>     - Preserves user-provided settings with higher thresholds or additional categories.
>   - **Misc**:
>     - Ensures user-specified safety configurations are respected while applying required settings when none are provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor&utm_source=github&utm_medium=referral)<sup> for ec178e4b4ba8aa3352db8e4a986c4e37a841a5a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->