### PR TITLE
Adding support for getattrs so that we can access normal methods on wrapped clients

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -275,6 +275,12 @@ class Instructor:
                 kwargs[key] = value
         return kwargs
 
+    def __getattr__(self, attr: str) -> Any:
+        if attr not in {"create", "chat", "messages"}:
+            return getattr(self.client, attr)
+
+        return getattr(self, attr)
+
 
 class AsyncInstructor(Instructor):
     client: Any | None

--- a/tests/llm/test_openai/test_attr.py
+++ b/tests/llm/test_openai/test_attr.py
@@ -1,0 +1,25 @@
+import instructor
+import openai
+import pytest
+
+
+def test_has_embedding():
+    oai = openai.OpenAI()
+    client = instructor.from_openai(oai)
+
+    embedding = client.embeddings.create(
+        input="Hello world", model="text-embedding-3-small"
+    )
+    assert embedding is not None, "The 'embeddings' attribute is None."
+
+
+@pytest.mark.asyncio
+async def test_has_embedding_async():
+    oai = openai.AsyncOpenAI()
+    client = instructor.from_openai(oai)
+
+    # Check if the 'embeddings' attribute can be accessed through the client
+    embedding = await client.embeddings.create(
+        input="Hello world", model="text-embedding-3-small"
+    )
+    assert embedding is not None, "The 'embeddings' attribute is None."


### PR DESCRIPTION
This fixes #771  so that now we can do something like this

```
 oai = openai.OpenAI()
 client = instructor.from_openai(oai)
embedding = client.embeddings.create(
        input="Hello world", model="text-embedding-3-small"
)
```


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `__getattr__` to `Instructor` for accessing methods on wrapped clients, with tests for `embeddings.create`.
> 
>   - **Behavior**:
>     - Adds `__getattr__` to `Instructor` in `client.py` to access methods on wrapped clients, excluding `create`, `chat`, and `messages`.
>   - **Tests**:
>     - Adds `test_attr.py` to verify access to `embeddings.create` on wrapped `OpenAI` and `AsyncOpenAI` clients.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Finstructor&utm_source=github&utm_medium=referral)<sup> for a6d6b43f6a38043c52c43ecc6d147220c5766c77. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->