### PR TITLE
Disabling Prompting Tips

### DIFF
--- a/tests/llm/test_openai/docs/test_prompt_tips.py
+++ b/tests/llm/test_openai/docs/test_prompt_tips.py
@@ -3,6 +3,7 @@ from pytest_examples import find_examples, CodeExample, EvalExample
 
 
 @pytest.mark.parametrize("example", find_examples("docs/prompting"), ids=str)
+@pytest.mark.skip(reason="Skipping this for now")
 def test_format_concepts(example: CodeExample, eval_example: EvalExample):
     if eval_example.update_examples:
         eval_example.format(example)


### PR DESCRIPTION
Disabling prompting tips tests for now 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add skip marker to `test_format_concepts()` in `test_prompt_tips.py` to temporarily disable the test.
> 
>   - **Tests**:
>     - Add `@pytest.mark.skip` to `test_format_concepts()` in `test_prompt_tips.py` to disable the test temporarily.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 7b38c2573763db27144f98c8dae800309b51e201. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->