### PR TITLE
Added Jinja2 as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6105,4 +6105,4 @@ vertexai = ["google-cloud-aiplatform", "jsonref"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8413bb04ad220cc66b1498c83d97eaf9e7c5d32ea9cbbf8537863f341a60c605"
+content-hash = "379967b63bcaafa3a42f75d563b57114e7552a9d478e1372c747a9ce3475940c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ aiohttp = "^3.9.1"
 tenacity = ">=9.0.0,<10.0.0"
 pydantic-core = "^2.18.0"
 jiter = "^0.5.0"
+jinja2 = "^3.1.4"
 
 # dependency versions for extras
 fastapi = { version = "^0.109.2", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "1.6.0"
+version = "1.6.1"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"


### PR DESCRIPTION
Pyproject.toml has a missing jinja2 dependency at the moment that will cause a fresh installation to throw an error. This remedies the issue
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `jinja2` as a dependency in `pyproject.toml` to prevent installation errors.
> 
>   - **Dependencies**:
>     - Add `jinja2` version `^3.1.4` to `pyproject.toml` to prevent installation errors due to missing dependency.
>     - Update version to `1.6.1` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for f9bb7c1d4e3996069f2b194188f7673b0f56d972. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->