### PR TITLE
fix: Added off and clear proeprty to Instructor base class 

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -93,7 +93,7 @@ class Instructor:
                 "parse:error",
             ]
         )
-        | None,
+        | None = None,
     ) -> None:
         self.hooks.clear(hook_name)
 

--- a/instructor/client.py
+++ b/instructor/client.py
@@ -65,22 +65,6 @@ class Instructor:
     ) -> None:
         self.hooks.on(hook_name, handler)
 
-    def on(
-        self,
-        hook_name: (
-            HookName
-            | Literal[
-                "completion:kwargs",
-                "completion:response",
-                "completion:error",
-                "completion:last_attempt",
-                "parse:error",
-            ]
-        ),
-        handler: Callable[[Any], None],
-    ) -> None:
-        self.hooks.on(hook_name, handler)
-
     def off(
         self,
         hook_name: (

--- a/instructor/client.py
+++ b/instructor/client.py
@@ -65,6 +65,54 @@ class Instructor:
     ) -> None:
         self.hooks.on(hook_name, handler)
 
+    def on(
+        self,
+        hook_name: (
+            HookName
+            | Literal[
+                "completion:kwargs",
+                "completion:response",
+                "completion:error",
+                "completion:last_attempt",
+                "parse:error",
+            ]
+        ),
+        handler: Callable[[Any], None],
+    ) -> None:
+        self.hooks.on(hook_name, handler)
+
+    def off(
+        self,
+        hook_name: (
+            HookName
+            | Literal[
+                "completion:kwargs",
+                "completion:response",
+                "completion:error",
+                "completion:last_attempt",
+                "parse:error",
+            ]
+        ),
+        handler: Callable[[Any], None],
+    ) -> None:
+        self.hooks.off(hook_name, handler)
+
+    def clear(
+        self,
+        hook_name: (
+            HookName
+            | Literal[
+                "completion:kwargs",
+                "completion:response",
+                "completion:error",
+                "completion:last_attempt",
+                "parse:error",
+            ]
+        )
+        | None,
+    ) -> None:
+        self.hooks.clear(hook_name)
+
     @property
     def chat(self) -> Self:
         return self

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -157,3 +157,22 @@ def test_clear_method(
 
     client.clear(hook_enum)
     assert hook_enum not in client.hooks._handlers
+
+
+@pytest.mark.parametrize("hook_enum", hook_enums)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_clear_no_args(
+    client: instructor.Instructor,
+    hook_enum: instructor.hooks.HookName,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_enum, func)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    client.clear()
+    assert hook_enum not in client.hooks._handlers

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -33,11 +33,12 @@ def test_on_method_str(
     client: instructor.Instructor, hook_name: str, num_functions: int
 ):
     functions_to_add = hook_functions[:num_functions]
+    hook_enum = hook_object.get_hook_name(hook_name)
+
+    assert hook_enum not in client.hooks._handlers
 
     for func in functions_to_add:
         client.on(hook_name, func)
-
-    hook_enum = hook_object.get_hook_name(hook_name)
 
     assert hook_enum in client.hooks._handlers
     assert len(client.hooks._handlers[hook_enum]) == num_functions
@@ -54,6 +55,7 @@ def test_on_method_enum(
     num_functions: int,
 ):
     functions_to_add = hook_functions[:num_functions]
+    assert hook_enum not in client.hooks._handlers
 
     for func in functions_to_add:
         client.on(hook_enum, func)
@@ -73,11 +75,11 @@ def test_off_method_str(
     num_functions: int,
 ):
     functions_to_add = hook_functions[:num_functions]
+    hook_enum = hook_object.get_hook_name(hook_name)
+    assert hook_enum not in client.hooks._handlers
 
     for func in functions_to_add:
         client.on(hook_name, func)
-
-    hook_enum = hook_object.get_hook_name(hook_name)
 
     assert hook_enum in client.hooks._handlers
     assert len(client.hooks._handlers[hook_enum]) == num_functions
@@ -100,7 +102,7 @@ def test_off_method_enum(
     num_functions: int,
 ):
     functions_to_add = hook_functions[:num_functions]
-
+    assert hook_enum not in client.hooks._handlers
     for func in functions_to_add:
         client.on(hook_enum, func)
 

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -29,7 +29,7 @@ hook_object = instructor.hooks.Hooks()
 
 @pytest.mark.parametrize("hook_name", hook_names)
 @pytest.mark.parametrize("num_functions", [1, 2, 3])
-def test_multiple_hooks(
+def test_on_method_str(
     client: instructor.Instructor, hook_name: str, num_functions: int
 ):
     functions_to_add = hook_functions[:num_functions]
@@ -65,9 +65,36 @@ def test_on_method_enum(
         assert func in client.hooks._handlers[hook_enum]
 
 
+@pytest.mark.parametrize("hook_name", hook_names)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_off_method_str(
+    client: instructor.Instructor,
+    hook_name: str,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_name, func)
+
+    hook_enum = hook_object.get_hook_name(hook_name)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    for func in functions_to_add:
+        client.off(hook_name, func)
+        if client.hooks._handlers.get(hook_enum):
+            assert func not in client.hooks._handlers[hook_enum]
+        else:
+            assert hook_enum not in client.hooks._handlers
+
+    assert hook_enum not in client.hooks._handlers
+
+
 @pytest.mark.parametrize("hook_enum", hook_enums)
 @pytest.mark.parametrize("num_functions", [1, 2, 3])
-def test_off_method(
+def test_off_method_enum(
     client: instructor.Instructor,
     hook_enum: instructor.hooks.HookName,
     num_functions: int,
@@ -87,6 +114,27 @@ def test_off_method(
         else:
             assert hook_enum not in client.hooks._handlers
 
+    assert hook_enum not in client.hooks._handlers
+
+
+@pytest.mark.parametrize("hook_name", hook_names)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_clear_method_str(
+    client: instructor.Instructor,
+    hook_name: str,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_name, func)
+
+    hook_enum = hook_object.get_hook_name(hook_name)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    client.clear(hook_name)
     assert hook_enum not in client.hooks._handlers
 
 

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -1,0 +1,110 @@
+import pytest
+import instructor
+from openai import OpenAI, AsyncOpenAI
+import pprint
+
+
+@pytest.fixture
+def client():
+    return instructor.from_openai(OpenAI())
+
+
+def log_kwargs(*args, **kwargs):
+    pprint.pprint({"args": args, "kwargs": kwargs})
+
+
+def log_kwargs_1(*args, **kwargs):
+    pprint.pprint({"args": args, "kwargs": kwargs})
+
+
+def log_kwargs_2(*args, **kwargs):
+    pprint.pprint({"args": args, "kwargs": kwargs})
+
+
+# hook_names = [item.name for item in instructor.hooks.HookName]
+hook_names = [item.value for item in instructor.hooks.HookName]
+hook_enums = [instructor.hooks.HookName(hook_name) for hook_name in hook_names]
+hook_functions = [log_kwargs, log_kwargs_1, log_kwargs_2]
+hook_object = instructor.hooks.Hooks()
+
+
+@pytest.mark.parametrize("hook_name", hook_names)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_multiple_hooks(
+    client: instructor.Instructor, hook_name: str, num_functions: int
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_name, func)
+
+    hook_enum = hook_object.get_hook_name(hook_name)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    for func in functions_to_add:
+        assert func in client.hooks._handlers[hook_enum]
+
+
+@pytest.mark.parametrize("hook_enum", hook_enums)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_on_method_enum(
+    client: instructor.Instructor,
+    hook_enum: instructor.hooks.HookName,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_enum, func)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    for func in functions_to_add:
+        assert func in client.hooks._handlers[hook_enum]
+
+
+@pytest.mark.parametrize("hook_enum", hook_enums)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_off_method(
+    client: instructor.Instructor,
+    hook_enum: instructor.hooks.HookName,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_enum, func)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    for func in functions_to_add:
+        client.off(hook_enum, func)
+        if client.hooks._handlers.get(hook_enum):
+            assert func not in client.hooks._handlers[hook_enum]
+        else:
+            assert hook_enum not in client.hooks._handlers
+
+    assert hook_enum not in client.hooks._handlers
+
+
+@pytest.mark.parametrize("hook_enum", hook_enums)
+@pytest.mark.parametrize("num_functions", [1, 2, 3])
+def test_clear_method(
+    client: instructor.Instructor,
+    hook_enum: instructor.hooks.HookName,
+    num_functions: int,
+):
+    functions_to_add = hook_functions[:num_functions]
+
+    for func in functions_to_add:
+        client.on(hook_enum, func)
+
+    assert hook_enum in client.hooks._handlers
+    assert len(client.hooks._handlers[hook_enum]) == num_functions
+
+    client.clear(hook_enum)
+    assert hook_enum not in client.hooks._handlers

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -1,6 +1,6 @@
 import pytest
 import instructor
-from openai import OpenAI, AsyncOpenAI
+from openai import OpenAI
 import pprint
 
 

--- a/tests/llm/test_openai/test_hooks.py
+++ b/tests/llm/test_openai/test_hooks.py
@@ -21,7 +21,6 @@ def log_kwargs_2(*args, **kwargs):
     pprint.pprint({"args": args, "kwargs": kwargs})
 
 
-# hook_names = [item.name for item in instructor.hooks.HookName]
 hook_names = [item.value for item in instructor.hooks.HookName]
 hook_enums = [instructor.hooks.HookName(hook_name) for hook_name in hook_names]
 hook_functions = [log_kwargs, log_kwargs_1, log_kwargs_2]


### PR DESCRIPTION
This fixes a bug whereby we would get `off` or `clear` is not a property on the `client` itself
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `off` and `clear` methods to `Instructor` for hook management, refactors hook handling, and adds tests.
> 
>   - **Behavior**:
>     - Adds `off` and `clear` methods to `Instructor` class in `client.py` for managing hook handlers.
>     - `off` removes a specific handler for a hook, `clear` removes all handlers for a hook or all hooks.
>   - **Refactoring**:
>     - Adds `get_hook_name` method in `hooks.py` to standardize hook name conversion.
>     - Refactors `on`, `off`, and `clear` methods in `hooks.py` to use `get_hook_name` for consistent hook name handling.
>   - **Testing**:
>     - Adds `test_hooks.py` to test `on`, `off`, and `clear` methods for multiple hooks and handlers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 30e169c3a725903dbe2cfd6dc1c528656094465e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->