### PR TITLE
Bumping version to 1.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "instructor"
-version = "1.6.1"
+version = "1.6.2"
 description = "structured outputs for llm"
 authors = ["Jason Liu <jason@jxnl.co>"]
 license = "MIT"


### PR DESCRIPTION
Bumping version of instructor to 1.6.2
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps version of `instructor` from `1.6.1` to `1.6.2` in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bumps version of `instructor` from `1.6.1` to `1.6.2` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for f6ab64daca0cbd348c984e6c467456a79973031e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->