### PR TITLE
gpt 3.5 turbo updated to gpt-40-mini since July 2024 it is recommende…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ client = instructor.from_openai(OpenAI())
 
 # Extract structured data from natural language
 user_info = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
     response_model=UserInfo,
     messages=[{"role": "user", "content": "John Doe is 30 years old."}],
 )
@@ -84,7 +84,7 @@ client.on("completion:kwargs", log_kwargs)
 client.on("completion:error", log_exception)
 
 user_info = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
     response_model=UserInfo,
     messages=[{"role": "user", "content": "Extract the user name: 'John is 20 years old'"}],
 )
@@ -99,7 +99,7 @@ user_info = client.chat.completions.create(
                     'content': "Extract the user name: 'John is 20 years old'",
                 }
             ],
-            'model': 'gpt-3.5-turbo',
+            'model': 'gpt-4o-mini',
             'tools': [
                 {
                     'type': 'function',


### PR DESCRIPTION
README Update - gpt-3.5-turbo updated to gpt-40-mini since July 2024 it is recommended to use gpt-4o-mini instead of gpt-3.5-turbo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update model in `README.md` from `gpt-3.5-turbo` to `gpt-4o-mini` for `client.chat.completions.create()` examples.
> 
>   - **Behavior**:
>     - Update model from `gpt-3.5-turbo` to `gpt-4o-mini` in `README.md` for examples using `client.chat.completions.create()`.
>     - Reflects recommendation change since July 2024.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for cdd023b8f97f8bbd03dfaa8dbce0ab971ead337c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->