### PR TITLE
feat: fix `max_retries` typing

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -13,6 +13,10 @@ from typing import (
     Literal,
     Any,
 )
+from tenacity import (
+    AsyncRetrying,
+    Retrying,
+)
 from collections.abc import Generator, Iterable, Awaitable, AsyncGenerator
 from typing_extensions import Self
 from pydantic import BaseModel
@@ -114,7 +118,7 @@ class Instructor:
         self: AsyncInstructor,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
@@ -126,7 +130,7 @@ class Instructor:
         self: Self,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
@@ -138,7 +142,7 @@ class Instructor:
         self: AsyncInstructor,
         response_model: None,
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
@@ -150,7 +154,7 @@ class Instructor:
         self: Self,
         response_model: None,
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
@@ -161,7 +165,7 @@ class Instructor:
         self,
         response_model: type[T] | None,
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -185,7 +189,7 @@ class Instructor:
         self: AsyncInstructor,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,  # {{ edit_1 }}
         strict: bool = True,
@@ -197,7 +201,7 @@ class Instructor:
         self: Self,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -208,7 +212,7 @@ class Instructor:
         self,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -235,7 +239,7 @@ class Instructor:
         self: AsyncInstructor,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -247,7 +251,7 @@ class Instructor:
         self: Self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -258,7 +262,7 @@ class Instructor:
         self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -284,7 +288,7 @@ class Instructor:
         self: AsyncInstructor,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -296,7 +300,7 @@ class Instructor:
         self: Self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -307,7 +311,7 @@ class Instructor:
         self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -373,7 +377,7 @@ class AsyncInstructor(Instructor):
         self,
         response_model: type[T] | None,
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -395,7 +399,7 @@ class AsyncInstructor(Instructor):
         self,
         response_model: type[T],
         messages: list[ChatCompletionMessageParam],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -419,7 +423,7 @@ class AsyncInstructor(Instructor):
         self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,
@@ -443,7 +447,7 @@ class AsyncInstructor(Instructor):
         self,
         messages: list[ChatCompletionMessageParam],
         response_model: type[T],
-        max_retries: int = 3,
+        max_retries: int | Retrying | AsyncRetrying = 3,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
         strict: bool = True,

--- a/instructor/patch.py
+++ b/instructor/patch.py
@@ -22,6 +22,11 @@ from instructor.templating import handle_templating
 from instructor.mode import Mode
 import logging
 
+from tenacity import (
+    AsyncRetrying,
+    Retrying,
+)
+
 logger = logging.getLogger("instructor")
 
 T_Model = TypeVar("T_Model", bound=BaseModel)
@@ -35,7 +40,7 @@ class InstructorChatCompletionCreate(Protocol):
         response_model: type[T_Model] | None = None,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
-        max_retries: int = 1,
+        max_retries: int | Retrying | AsyncRetrying = 1,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model: ...
@@ -47,7 +52,7 @@ class AsyncInstructorChatCompletionCreate(Protocol):
         response_model: type[T_Model] | None = None,
         validation_context: dict[str, Any] | None = None,  # Deprecate in 2.0
         context: dict[str, Any] | None = None,
-        max_retries: int = 1,
+        max_retries: int | Retrying | AsyncRetrying = 1,
         *args: Any,
         **kwargs: Any,
     ) -> T_Model: ...
@@ -140,7 +145,7 @@ def patch(  # type: ignore
         response_model: type[T_Model] | None = None,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
-        max_retries: int = 1,
+        max_retries: int | Retrying | AsyncRetrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
         *args: T_ParamSpec.args,
@@ -171,7 +176,7 @@ def patch(  # type: ignore
         response_model: type[T_Model] | None = None,
         validation_context: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
-        max_retries: int = 1,
+        max_retries: int | Retrying | AsyncRetrying = 1,
         strict: bool = True,
         hooks: Hooks | None = None,
         *args: T_ParamSpec.args,


### PR DESCRIPTION
When working on a project and [reviewing the docs](https://python.useinstructor.com/concepts/retrying/?h=tenacity#retry-callbacks) I noticed that there were `# type: ignore` references when using a `tenacity`  `Retrying | AsyncRetrying` object.

This PR aims to fix the underlying `type issues` as it seems `max_retries` can always be one of: `int | Retrying | AsyncRetrying`