### PR TITLE
fix: fixed up tenacity link

### DIFF
--- a/docs/blog/posts/chat-with-your-pdf-with-gemini.md
+++ b/docs/blog/posts/chat-with-your-pdf-with-gemini.md
@@ -93,7 +93,7 @@ The combination of Gemini and Instructor offers several key advantages over trad
 
 **Simple Integration** - Unlike traditional approaches that require complex document processing pipelines, chunking strategies, and embedding databases, you can directly process PDFs with just a few lines of code. This dramatically reduces development time and maintenance overhead.
 
-**Structured Output** - Instructor's Pydantic integration ensures you get exactly the data structure you need. The model's outputs are automatically validated and typed, making it easier to build reliable applications. If the extraction fails, Instructor automatically handles the retries for you with support for [custom retry logic using tenacity].
+**Structured Output** - Instructor's Pydantic integration ensures you get exactly the data structure you need. The model's outputs are automatically validated and typed, making it easier to build reliable applications. If the extraction fails, Instructor automatically handles the retries for you with support for [custom retry logic using tenacity](../../concepts/retrying.md).
 
 **Multimodal Support** - Gemini's multimodal capabilities mean this same approach works for various file types. You can process images, videos, and audio files all in the same api request. Check out our [multimodal processing guide](./multimodal-gemini.md) to see how we extract structured data from travel videos.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes hyperlink in `chat-with-your-pdf-with-gemini.md` to correctly point to retry logic documentation.
> 
>   - **Documentation**:
>     - Fixes hyperlink in `chat-with-your-pdf-with-gemini.md` to correctly point to `../../concepts/retrying.md` for custom retry logic using tenacity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 0b49ff9291d6e38e1548e9124a8fa70e21310c46. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->