### PR TITLE
docs: add learnprompting to prompting docs description

### DIFF
--- a/docs/prompting/index.md
+++ b/docs/prompting/index.md
@@ -5,9 +5,12 @@ description: Explore 58 effective prompting techniques categorized for enhanced 
 
 # Prompting Guide
 
-Prompting requires understanding of techniques. Prompting enhances model performance.
+Prompting requires an understanding of techniques to enhance model performance.
 
-We created examples of 58 prompting techniques<sup><a href="https://arxiv.org/abs/2406.06608">\*</a></sup> using `instructor`.
+The team at [Learn Prompting](https://learnprompting.org) released The Prompt Report in collaboration with researchers from OpenAI, Microsoft, and Google.
+This report surveys over 1,500 prompting papers and condenses the findings into a list of 58 distinct prompting techniques.
+
+Here are examples of the 58 prompting techniques<sup><a href="https://arxiv.org/abs/2406.06608">\*</a></sup> using `instructor`.
 
 Prompting techniques are separated into the following categories:
 - [Prompting Guide](#prompting-guide)

--- a/docs/prompting/index.md
+++ b/docs/prompting/index.md
@@ -7,10 +7,10 @@ description: Explore 58 effective prompting techniques categorized for enhanced 
 
 Prompting requires an understanding of techniques to enhance model performance.
 
-The team at [Learn Prompting](https://learnprompting.org) released The Prompt Report in collaboration with researchers from OpenAI, Microsoft, and Google.
+The team at [Learn Prompting](https://learnprompting.org) released The [Prompt Report](https://trigaten.github.io/Prompt_Survey_Site) in collaboration with researchers from OpenAI, Microsoft, and Google.
 This report surveys over 1,500 prompting papers and condenses the findings into a list of 58 distinct prompting techniques.
 
-Here are examples of the 58 prompting techniques<sup><a href="https://arxiv.org/abs/2406.06608">\*</a></sup> using `instructor`.
+Here are examples of the 58 prompting techniques<sup>*</sup> using `instructor`.
 
 Prompting techniques are separated into the following categories:
 - [Prompting Guide](#prompting-guide)


### PR DESCRIPTION
Updated the description of [this](https://python.useinstructor.com/prompting/) doc to include [Learn Prompting](https://learnprompting.org) in its description.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated `docs/prompting/index.md` to include Learn Prompting's collaboration and context about The Prompt Report.
> 
>   - **Documentation**:
>     - Updated `docs/prompting/index.md` to include Learn Prompting's collaboration with OpenAI, Microsoft, and Google.
>     - Added context about The Prompt Report, which surveys over 1,500 prompting papers and lists 58 techniques.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 930eaaeb8c948a4d22e109acdf327b8b70c5254a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->