### PR TITLE
fix: adding type ignore for pyright

### DIFF
--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -106,10 +106,10 @@ def _make_field_optional(
         tmp_field.annotation = Optional[Partial[annotation, MakeFieldsOptional]]  # type: ignore[assignment, valid-type]
         tmp_field.default = {}
     else:
-        tmp_field.annotation = Optional[field.annotation]
+        tmp_field.annotation = Optional[field.annotation]  # type:ignore
         tmp_field.default = None
 
-    return tmp_field.annotation, tmp_field
+    return tmp_field.annotation, tmp_field  # type: ignore
 
 
 class PartialBase(Generic[T_Model]):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add type ignore comments for pyright in `_make_field_optional()` in `partial.py`.
> 
>   - **Type Ignore Comments**:
>     - Added `# type: ignore` to `tmp_field.annotation = Optional[field.annotation]` in `_make_field_optional()`.
>     - Added `# type: ignore` to `return tmp_field.annotation, tmp_field` in `_make_field_optional()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for d06f540f82bd3c2c399efc2c923d3153815cc501. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->