### PR TITLE
Feat: Add beta support for anthropic

### DIFF
--- a/docs/integrations/anthropic.md
+++ b/docs/integrations/anthropic.md
@@ -241,3 +241,45 @@ response = client.chat.completions.create(
     autodetect_images=True
 )
 ```
+
+## Beta support
+The Anthropic beta API has [multiple features](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support) other than those mentioned above. You can access the beta api by setting the beta flag to `True` when creating your client. The example below shows extraction from a pdf.
+
+```python
+import instructor
+import requests
+import base64
+from pydantic import BaseModel
+from anthropic import Anthropic
+
+class Character(BaseModel):
+    name: str
+    description: str
+
+client = instructor.from_anthropic(anthropic.AsyncAnthropic(), beta=True)
+
+pdf_data=base64.b64encode(requests.get("https://freekidsbooks.org/wp-content/uploads/2019/12/FKB-Kids-Stories-Peter-Rabbit.pdf").content).decode()
+
+extracted_content = await self.instructor_client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        betas=["pdfs-2024-09-25"],
+        max_tokens=1024,
+        messages=[
+            {"role": "system", "content": "Extract a character from the pdf and describe them from any pictures ine the document"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": pdf_data,
+                        },
+                    },
+                ],
+            },
+        ],
+        response_model=Character,
+    )
+```

--- a/instructor/client_anthropic.py
+++ b/instructor/client_anthropic.py
@@ -41,6 +41,7 @@ def from_anthropic(
     ),
     mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
     enable_prompt_caching: bool = False,
+    beta:bool = False,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:
     assert (
@@ -70,6 +71,8 @@ def from_anthropic(
             raise TypeError(
                 "Client must be an instance of {anthropic.Anthropic, anthropic.AsyncAnthropic} to enable prompt caching"
             )
+    elif beta:
+        create = client.beta.messages.create
     else:
         create = client.messages.create
 


### PR DESCRIPTION
The anthropic beta API has [multiple features](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support)  other than those currently supported by instructor. This PR enables the ability to connect to the beta api endpoint to use any of them.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `beta` parameter to `from_anthropic()` in `client_anthropic.py` to support beta message creation.
> 
>   - **Behavior**:
>     - Adds `beta` parameter to `from_anthropic()` in `client_anthropic.py`.
>     - When `beta` is true, uses `client.beta.messages.create` instead of `client.messages.create`.
>   - **Functionality**:
>     - Supports both synchronous and asynchronous `client` types.
>     - Ensures compatibility with `enable_prompt_caching` and `beta` parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 047a5bb609a8c22a85951cd4a4af3c5024c812f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->