### PR TITLE
Support individual partial enum values

### DIFF
--- a/instructor/dsl/parallel.py
+++ b/instructor/dsl/parallel.py
@@ -16,6 +16,11 @@ from instructor.mode import Mode
 
 T = TypeVar("T", bound=OpenAISchema)
 
+class MissingToolCall(Exception):
+    def __init__(self, response: Any, *args: Any) -> None:
+        super().__init__(*args)
+        self.response = response
+
 
 class ParallelBase:
     def __init__(self, *models: type[OpenAISchema]):
@@ -37,6 +42,9 @@ class ParallelBase:
         #! We expect this from the OpenAISchema class, We should address
         #! this with a protocol or an abstract class... @jxnlco
         assert mode == Mode.PARALLEL_TOOLS, "Mode must be PARALLEL_TOOLS"
+        if not response.choices[0].message.tool_calls:
+            raise MissingToolCall(response)
+
         for tool_call in response.choices[0].message.tool_calls:
             name = tool_call.function.name
             arguments = tool_call.function.arguments

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -75,13 +75,17 @@ def _process_generic_arg(
     if arg_origin is not None:
         # Handle any nested generic type (Union, List, Dict, etc.)
         nested_args = get_args(arg)
-        modified_nested_args = tuple(
+        modified_nested_args = [
             _process_generic_arg(
                 t,
                 make_fields_optional=make_fields_optional,
             )
             for t in nested_args
-        )
+        ]
+        if make_fields_optional and Partial in modified_nested_args:
+            modified_nested_args.append(PartialValidator())
+
+        modified_nested_args = tuple(modified_nested_args)
         # Special handling for Union types (types.UnionType isn't subscriptable)
         if arg_origin in UNION_ORIGINS:
             return Union[modified_nested_args]  # type: ignore

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -14,10 +14,9 @@ from pydantic import (
     ValidationError,
     ValidatorFunctionWrapHandler,
     create_model,
-    BeforeValidator,
     WrapValidator,
 )
-from typing import Literal, Union, Any, Annotated
+from typing import Union, Any, Annotated
 import types
 import sys
 from pydantic.fields import FieldInfo

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -9,7 +9,14 @@
 from __future__ import annotations
 
 from jiter import from_json
-from pydantic import BaseModel, create_model, BeforeValidator
+from pydantic import (
+    BaseModel,
+    ValidationError,
+    ValidatorFunctionWrapHandler,
+    create_model,
+    BeforeValidator,
+    WrapValidator,
+)
 from typing import Literal, Union, Any, Annotated
 import types
 import sys
@@ -47,14 +54,18 @@ class PartialLiteralMixin:
     pass
 
 
-class PartialLiteralValidator(BeforeValidator):
-    def __init__(self, literal_type: Any, **kwargs: Any):
-        def validate_literal(v: Any) -> Optional[Any]:
-            if v in get_args(literal_type):
-                return v
-            return None
+class PartialValidator(WrapValidator):
+    def __init__(self, **kwargs: Any):
+        def validate_partial(
+            v: Any,
+            validator: ValidatorFunctionWrapHandler,
+        ) -> Optional[Any]:
+            try:
+                return validator(v)
+            except ValidationError:
+                return None
 
-        super().__init__(func=validate_literal, **kwargs)
+        super().__init__(func=validate_partial, **kwargs)
 
 
 def _process_generic_arg(
@@ -101,20 +112,14 @@ def _make_field_optional(
         generic_base = get_origin(annotation)
         generic_args = get_args(annotation)
 
-        if generic_base is Literal and Partial in field.metadata:
-            literal_types: set[type[Any]] = {type(arg) for arg in generic_args}
-            tmp_field.annotation = Annotated[Optional[Union[tuple(literal_types)]], PartialLiteralValidator(annotation)]  # type: ignore
-            tmp_field.default = None
-        else:
-            modified_args = tuple(
-                _process_generic_arg(arg, make_fields_optional=True)
-                for arg in generic_args
-            )
-            tmp_annotation: Any = Optional[generic_base[modified_args]] if generic_base else None  # type: ignore
+        modified_args = tuple(
+            _process_generic_arg(arg, make_fields_optional=True) for arg in generic_args
+        )
+        tmp_annotation: Any = Optional[generic_base[modified_args]] if generic_base else None  # type: ignore
 
-            # Reconstruct the generic type with modified arguments
-            tmp_field.annotation = tmp_annotation
-            tmp_field.default = None
+        # Reconstruct the generic type with modified arguments
+        tmp_field.annotation = tmp_annotation
+        tmp_field.default = None
     # If the field is a BaseModel, then recursively convert it's
     # attributes to optionals.
     elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
@@ -123,6 +128,14 @@ def _make_field_optional(
     else:
         tmp_field.annotation = Optional[field.annotation]  # type:ignore
         tmp_field.default = None
+
+    # If a field is annotated with Partial, add the PartialValidator which will
+    # return None if validation fails
+    if Partial in field.metadata:
+        tmp_field.annotation = Annotated[
+            tmp_field.annotation,
+            PartialValidator(),
+        ]  # type:ignore
 
     return tmp_field.annotation, tmp_field  # type: ignore
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -233,6 +233,7 @@ def test_partial_enums():
     assert partial_validated.i is not None
     assert partial_validated.i.c is None
 
+
     with pytest.raises(ValidationError):
         partial.model_validate_json(partial_results)
 

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1,6 +1,6 @@
 # type: ignore[all]
-from pydantic import BaseModel, Field
-from typing import Optional, Union
+from pydantic import BaseModel, Field, ValidationError
+from typing import Optional, Union, Literal, Annotated
 from instructor.dsl.partial import Partial, PartialLiteralMixin
 import pytest
 import instructor
@@ -37,6 +37,19 @@ class UnionWithNested(BaseModel):
     a: list[Union[NestedA, NestedB]]
     b: list[NestedA]
     c: NestedB
+
+
+SampleEnum = Literal["a_value", "b_value", "c_value"]
+SampleMixedEnum = Literal["a_value", "b_value", "c_value", 1, 2, 3]
+
+
+class PartialEnums(BaseModel):
+    a: Annotated[Literal["a_value"], Partial]
+    b: Annotated[SampleEnum, Partial]
+    c: Annotated[SampleMixedEnum, Partial]
+    d: Annotated[Literal["a_value", 10], Partial]
+    e: Annotated[Literal["a_value"], Partial]
+    f: Literal["a_value"]
 
 
 def test_partial():
@@ -192,3 +205,19 @@ def test_union_with_nested():
     partial.get_partial_model().model_validate_json(
         '{"a": [{"b": "b"}, {"d": "d"}], "b": [{"b": "b"}], "c": {"d": "d"}, "e": [1, "a"]}'
     )
+
+
+def test_partial_enums():
+    # Test that we can annotate enum values with `Partial` and support parsing
+    # partial values with the partial model
+    partial = Partial[PartialEnums]
+    partial_results = (
+        '{"a": "a_", "b": "b_", "c": "c_v", "d": 10, "e": "a_", "f": "a_value"}'
+    )
+    partial.get_partial_model().model_validate_json(partial_results)
+    with pytest.raises(ValidationError):
+        partial.model_validate_json(partial_results)
+
+    with pytest.raises(ValidationError):
+        # "f" is not marked as a partil enum
+        partial.get_partial_model().model_validate_json('{"f": "a_"}')

--- a/tests/dsl/test_partial.py
+++ b/tests/dsl/test_partial.py
@@ -1,4 +1,5 @@
 # type: ignore[all]
+from uuid import UUID
 from pydantic import BaseModel, Field, ValidationError, validator
 from typing import Optional, Union, Literal, Annotated
 from instructor.dsl.partial import Partial, PartialLiteralMixin
@@ -50,6 +51,7 @@ class PartialEnums(BaseModel):
     d: Annotated[Literal["a_value", 10], Partial]
     e: Annotated[Literal["a_value"], Partial]
     f: Literal["a_value"]
+    g: Annotated[UUID, Partial]
 
 
 def test_partial():
@@ -212,7 +214,7 @@ def test_partial_enums():
     # partial values with the partial model
     partial = Partial[PartialEnums]
     partial_results = (
-        '{"a": "a_", "b": "b_", "c": "c_v", "d": 1, "e": "a_", "f": "a_value"}'
+        '{"a": "a_", "b": "b_", "c": "c_v", "d": 1, "e": "a_", "f": "a_value", "g": "1"}'
     )
     partial_validated = partial.get_partial_model().model_validate_json(partial_results)
 
@@ -222,7 +224,7 @@ def test_partial_enums():
     assert partial_validated.d is None
     assert partial_validated.e is None
     assert partial_validated.f == "a_value"
-
+    assert partial_validated.g is None
     with pytest.raises(ValidationError):
         partial.model_validate_json(partial_results)
 
@@ -231,7 +233,7 @@ def test_partial_enums():
         partial.get_partial_model().model_validate_json('{"f": "a_"}')
 
     resolved_enum_partial_results = (
-        '{"a": "a_value", "b": "b_value", "c": "c_v", "d": 10}'
+        '{"a": "a_value", "b": "b_value", "c": "c_v", "d": 10, "g": "123e4567-e89b-12d3-a456-426655440000"}'
     )
     resolved_enum_partial_validated = partial.get_partial_model().model_validate_json(
         resolved_enum_partial_results
@@ -241,3 +243,4 @@ def test_partial_enums():
     # this value still isn't fully resolved
     assert resolved_enum_partial_validated.c is None
     assert resolved_enum_partial_validated.d == 10
+    assert resolved_enum_partial_validated.g == UUID("123e4567-e89b-12d3-a456-426655440000")


### PR DESCRIPTION
If you use literal values with partial it fails as the model is generating partial values. `PartialLiteralMixin` is one approach to fixing this but then means no other string values will stream as they're processed.

This is another approach that doesn't change how we parse the JSON, but just means the partial model won't validate these enums until they're fully resolved.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for handling partial enum values in JSON parsing using `PartialLiteralValidator` and updates tests accordingly.
> 
>   - **Behavior**:
>     - Introduces `PartialLiteralValidator` in `partial.py` to handle partial enum values.
>     - Updates `_make_field_optional()` to use `PartialLiteralValidator` for `Literal` types with `Partial`.
>   - **Tests**:
>     - Adds `test_partial_enums()` in `test_partial.py` to validate partial enum handling.
>     - Ensures enums are not validated until fully resolved, except for non-partial fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 15d0093c97210264a10fd030ac501744a55e956a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->