### PR TITLE
fix: BatchJob is updated to work with current OpenAi batch request format

### DIFF
--- a/instructor/batch.py
+++ b/instructor/batch.py
@@ -31,7 +31,9 @@ class RequestBody(BaseModel):
 
 class BatchModel(BaseModel):
     custom_id: str
-    params: RequestBody
+    body: RequestBody
+    url: str
+    method: str
 
 
 class BatchJob:
@@ -149,12 +151,14 @@ class BatchJob:
                 for messages in messages_batch:
                     batch_model = BatchModel(
                         custom_id=str(uuid.uuid4()),
-                        params=RequestBody(
+                        body=RequestBody(
                             model=model,
                             messages=messages,
                             max_tokens=max_tokens,
                             temperature=temperature,
                             **kwargs,
                         ),
+                        method="POST",
+                        url="/v1/chat/completions"
                     )
                     file.write(batch_model.model_dump_json() + "\n")


### PR DESCRIPTION
The BatchJob implementation for OpenAi is currently broken as a number of fields appears to have changed or have been updated on OpenAi's side and won't pass the validation stage.

This PR adds and updates the required fields to match the batch completion request API as it currently stands.
https://platform.openai.com/docs/api-reference/batch/object

- Adds a `method` field which is set to `POST` as it's the only thing supported by OpenAi right now.
- Adds a `url` field which is set to `/v1/chat/completions` as this BatchJob class appears to only support chat completions anyway.
- Change `params` to `body` as specified by the OpenAi docs for the batch input file example.
https://platform.openai.com/docs/api-reference/batch/request-input