### PR TITLE
Ollama tools

### DIFF
--- a/instructor/__init__.py
+++ b/instructor/__init__.py
@@ -96,3 +96,8 @@ if importlib.util.find_spec("writerai") is not None:
     from .client_writer import from_writer
 
     __all__ += ["from_writer"]
+
+if importlib.util.find_spec("ollama") is not None:
+    from .client_ollama import from_ollama
+
+    __all__ += ["from_ollama"]

--- a/instructor/client_ollama.py
+++ b/instructor/client_ollama.py
@@ -22,7 +22,7 @@ def from_ollama(
     client: (
        ollama.AsyncClient
     ),
-    mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
+    mode: instructor.Mode = instructor.Mode.OLLAMA_TOOLS,
     **kwargs: Any,
 ) -> instructor.AsyncInstructor: ...
 

--- a/instructor/client_ollama.py
+++ b/instructor/client_ollama.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, overload
+
+import ollama
+
+import instructor
+
+
+@overload
+def from_ollama(
+    client: (
+        ollama.Client
+    ),
+    mode: instructor.Mode = instructor.Mode.OLLAMA_TOOLS,
+    **kwargs: Any,
+) -> instructor.Instructor: ...
+
+
+@overload
+def from_ollama(
+    client: (
+       ollama.AsyncClient
+    ),
+    mode: instructor.Mode = instructor.Mode.ANTHROPIC_TOOLS,
+    **kwargs: Any,
+) -> instructor.AsyncInstructor: ...
+
+
+def from_ollama(
+    client: (
+        ollama.Client
+        | ollama.AsyncClient
+    ),
+    mode: instructor.Mode = instructor.Mode.OLLAMA_TOOLS,
+    **kwargs: Any,
+) -> instructor.Instructor | instructor.AsyncInstructor:
+    assert (
+        mode
+        in {
+            instructor.Mode.OLLAMA_TOOLS,
+        }
+    ), "Mode be one of {instructor.Mode.OLLAMA_TOOLS}"
+
+    assert isinstance(
+        client,
+        (
+            ollama.Client,
+            ollama.AsyncClient,
+        ),
+    ), "Client must be an instance of {ollama.Client, ollama.AsyncClient}"
+
+    create = client.chat
+
+    if isinstance(
+        client,
+        (
+            ollama.Client,
+        ),
+    ):
+        return instructor.Instructor(
+            client=client,
+            create=instructor.patch(create=create, mode=mode),
+            provider=instructor.Provider.OLLAMA,
+            mode=mode,
+            **kwargs,
+        )
+
+    else:
+        return instructor.AsyncInstructor(
+            client=client,
+            create=instructor.patch(create=create, mode=mode),
+            provider=instructor.Provider.OLLAMA,
+            mode=mode,
+            **kwargs,
+        )

--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -27,6 +27,7 @@ class Mode(enum.Enum):
     FIREWORKS_TOOLS = "fireworks_tools"
     FIREWORKS_JSON = "fireworks_json"
     WRITER_TOOLS = "writer_tools"
+    OLLAMA_TOOLS = "ollama_tools"
 
     @classmethod
     def warn_mode_functions_deprecation(cls):

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -596,6 +596,12 @@ def handle_writer_tools(
     new_kwargs["tool_choice"] = "auto"
     return response_model, new_kwargs
 
+def handle_ollama_tools(
+    response_model: type[T], new_kwargs: dict[str, Any]
+) -> tuple[type[T], dict[str, Any]]:
+    new_kwargs["format"] = response_model.model_json_schema()
+    return response_model, new_kwargs
+
 
 def is_typed_dict(cls) -> bool:
     return (
@@ -715,6 +721,7 @@ def handle_response_model(
         Mode.FIREWORKS_JSON: handle_fireworks_json,
         Mode.FIREWORKS_TOOLS: handle_fireworks_tools,
         Mode.WRITER_TOOLS: handle_writer_tools,
+        Mode.OLLAMA_TOOLS: handle_ollama_tools,
     }
 
     if mode in mode_handlers:

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -54,6 +54,7 @@ class Provider(Enum):
     CEREBRAS = "cerebras"
     FIREWORKS = "fireworks"
     WRITER = "writer"
+    OLLAMA = "ollama"
     UNKNOWN = "unknown"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ jsonref = { version = "^1.1.0", optional = true }
 cerebras_cloud_sdk = { version = "^1.5.0", optional = true }
 fireworks-ai = { version = "^0.15.4", optional = true }
 writer-sdk = { version = "^1.2.0", optional = true }
+ollama-python = { version = "TODO", optional = true } # Ollama hasn't releaed a version yet
 
 [tool.poetry.extras]
 anthropic = ["anthropic", "xmltodict"]


### PR DESCRIPTION
Example

```python
from ollama import Client
from pydantic import BaseModel

import instructor


class UserInfo(BaseModel):
    name: str
    age: int


client = instructor.from_ollama(Client())

user_info = client.chat.completions.create(
    model="llama3.2",
    response_model=UserInfo,
    messages=[{"role": "user", "content": "John Doe is 30 years old."}],
)

print(user_info)
```

Ollama hasn't currently released the application with the structured outputs or the ollama-python package so this currently needs to be run with a local build. Follow their [Guide](https://github.com/ollama/ollama/blob/main/docs/development.md) to run.