### PR TITLE
Update simple_type.py

### DIFF
--- a/instructor/dsl/simple_type.py
+++ b/instructor/dsl/simple_type.py
@@ -26,7 +26,7 @@ class ModelAdapter(typing.Generic[T]):
         return create_model(
             "Response",
             content=(response_model, ...),
-            __doc__="Correctly Formated and Extracted Response.",
+            __doc__="Correctly Formatted and Extracted Response.",
             __base__=(AdapterBase, OpenAISchema),
         )
 


### PR DESCRIPTION
Fixed minor typo in documentation description template for JSON-schema- "formated" should be "formatted".
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `__class_getitem__()` docstring in `simple_type.py`.
> 
>   - **Documentation**:
>     - Fix typo in `__class_getitem__()` docstring in `simple_type.py`, changing "Formated" to "Formatted".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for e4c8c56dba73ce630c92fb9a82e93dccc868b347. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->