### PR TITLE
Adding support for Gemini-8b and 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
 
+      - name: Run Gemini Tests
+        if: matrix.python-version == '3.11'
+        run: poetry run pytest tests/llm/test_gemini
+        env:
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+
       - name: Generate coverage report
         if: matrix.python-version == '3.11'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,9 @@ jobs:
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
 
       - name: Run Gemini Tests
-        if: matrix.python-version == '3.11'
         run: poetry run pytest tests/llm/test_gemini
         env:
-          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Generate coverage report
         if: matrix.python-version == '3.11'

--- a/instructor/reask.py
+++ b/instructor/reask.py
@@ -108,6 +108,15 @@ def reask_gemini_tools(
 
     reask_msgs = [
         {
+            "role": "model",
+            "parts": [
+                glm.FunctionCall(
+                    name=response.parts[0].function_call.name,
+                    args=response.parts[0].function_call.args,
+                )
+            ],
+        },
+        {
             "role": "function",
             "parts": [
                 glm.Part(

--- a/tests/llm/test_gemini/util.py
+++ b/tests/llm/test_gemini/util.py
@@ -1,4 +1,4 @@
 import instructor
 
-models: list[str] = ["models/gemini-1.5-flash-latest"]
+models: list[str] = ["models/gemini-1.5-flash-8b"]
 modes = [instructor.Mode.GEMINI_TOOLS, instructor.Mode.GEMINI_JSON]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for Gemini-8b with updated tests and response handling in `reask_gemini_tools`.
> 
>   - **Testing**:
>     - Add Gemini tests in `.github/workflows/test.yml` for Python 3.11.
>     - Update `models` in `tests/llm/test_gemini/util.py` to include `gemini-1.5-flash-8b`.
>   - **Functionality**:
>     - Modify `reask_gemini_tools` in `instructor/reask.py` to handle new `glm.FunctionCall` response parts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 93fccf22bf4aaa082101b55919e213a088ec0f57. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->