### PR TITLE
fix: Updated broken contributors profile link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,6 @@ This project is licensed under the terms of the MIT License.
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-<a href="https://github.com/jxnl/instructor/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=jxnl/instructor" />
+<a href="https://github.com/instructor-ai/instructor/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=instructor-ai/instructor" />
 </a>


### PR DESCRIPTION
Fixed contributors profile link
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken contributors profile link in `README.md`.
> 
>   - **Documentation**:
>     - Fix broken contributors profile link in `README.md` by updating the URL to `https://github.com/instructor-ai/instructor/graphs/contributors` and the image source to `https://contrib.rocks/image?repo=instructor-ai/instructor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for dfd74b38e2e25f1c07f9dbb97733eef9dbad56f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->