### PR TITLE
Use GEMINI_JSON as default

### DIFF
--- a/docs/concepts/patching.md
+++ b/docs/concepts/patching.md
@@ -35,6 +35,7 @@ Gemini tool calling comes with some known limitations:
     - Gemini tool calling is incompatible with Pydantic schema customizations such as examples due to API limitations and may result in errors
     - Gemini can sometimes call the wrong function name, resulting in malformed or invalid json
     - Gemini tool calling could fail with enum and literal field types
+    - Gemini tool calling doesn't preserve the order of the fields in the response. Don't rely on the order of the fields in the response.
 
 ```python
 import instructor
@@ -45,7 +46,7 @@ client = instructor.from_gemini(
 )
 ```
 
-### Gemini Vertex AI Tool Callin
+### Gemini Vertex AI Tool Calling
 
 This method allows us to get structured output from Gemini via tool calling with the Vertex AI SDK.
 

--- a/instructor/client_gemini.py
+++ b/instructor/client_gemini.py
@@ -11,24 +11,26 @@ import instructor
 @overload
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
+    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
     use_async: Literal[True] = True,
     **kwargs: Any,
-) -> instructor.AsyncInstructor: ...
+) -> instructor.AsyncInstructor:
+    ...
 
 
 @overload
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
+    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
     use_async: Literal[False] = False,
     **kwargs: Any,
-) -> instructor.Instructor: ...
+) -> instructor.Instructor:
+    ...
 
 
 def from_gemini(
     client: genai.GenerativeModel,
-    mode: instructor.Mode = instructor.Mode.GEMINI_TOOLS,
+    mode: instructor.Mode = instructor.Mode.GEMINI_JSON,
     use_async: bool = False,
     **kwargs: Any,
 ) -> instructor.Instructor | instructor.AsyncInstructor:


### PR DESCRIPTION
Makes GEMINI_JSON default, and warns users about key ordering issue.

Fixes #1285.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default mode to `GEMINI_JSON` in `from_gemini()` and update documentation for field order warning.
> 
>   - **Behavior**:
>     - Change default mode to `GEMINI_JSON` in `from_gemini()` in `instructor/client_gemini.py`.
>     - Warns about field order issue in `docs/concepts/patching.md`.
>   - **Documentation**:
>     - Fix typo in section title in `docs/concepts/patching.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 25045ab358f6bbaa9a4c54219aafa726da2f3569. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->