### PR TITLE
Fix Markdown Titles

### DIFF
--- a/docs/examples/document_segmentation.md
+++ b/docs/examples/document_segmentation.md
@@ -1,5 +1,5 @@
 ---
-title: Document Segmentation with LLMs: A Comprehensive Guide
+title: 'Document Segmentation with LLMs: A Comprehensive Guide'
 description: Learn effective document segmentation techniques using Cohere's LLM, enhancing comprehension of complex texts.
 ---
 

--- a/docs/examples/groq.md
+++ b/docs/examples/groq.md
@@ -1,5 +1,5 @@
 ---
-title: Using Groq for Inference: Setup and Example
+title: 'Using Groq for Inference: Setup and Example'
 description: Learn how to use Groq for inference with the mixtral-8x7b model, including API setup and a practical Python example.
 ---
 

--- a/docs/examples/knowledge_graph.md
+++ b/docs/examples/knowledge_graph.md
@@ -1,5 +1,5 @@
 ---
-title: Visualizing Knowledge Graphs: A Guide to Complex Topics
+title: 'Visualizing Knowledge Graphs: A Guide to Complex Topics'
 description: Learn how to create and update knowledge graphs using Python, OpenAI's API, Pydantic, and Graphviz for enhanced understanding of complex subjects.
 ---
 

--- a/docs/examples/planning-tasks.md
+++ b/docs/examples/planning-tasks.md
@@ -1,5 +1,5 @@
 ---
-title: Query Planning with OpenAI: A Step-by-Step Guide
+title: 'Query Planning with OpenAI: A Step-by-Step Guide'
 description: Learn how to effectively plan and execute complex query plans using OpenAI's Function Call model for systematic information gathering.
 ---
 


### PR DESCRIPTION
several titles in docs/examples have colon ( : ) in title, which is not valid unless the string in quotes. added quotes around titles

see: 

https://python.useinstructor.com/examples/document_segmentation/

https://python.useinstructor.com/examples/planning-tasks/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add quotes around Markdown titles with colons in four documentation files to ensure valid syntax.
> 
>   - **Markdown Titles**:
>     - Add quotes around titles with colons in `document_segmentation.md`, `groq.md`, `knowledge_graph.md`, and `planning-tasks.md` to ensure valid Markdown syntax.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 422c868063adc831df154f04efba33f55950be62. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->