### PR TITLE
Predicted tokens support in instructor

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -152,6 +152,8 @@ def update_total_usage(
             ttd.reasoning_tokens = (ttd.reasoning_tokens or 0) + (
                 rtd.reasoning_tokens or 0
             )
+            ttd.accepted_prediction_tokens = (ttd.accepted_prediction_tokens or 0) + (rtd.accepted_prediction_tokens or 0)
+            ttd.rejected_prediction_tokens = (ttd.rejected_prediction_tokens or 0) + (rtd.rejected_prediction_tokens or 0)
         if (rpd := response_usage.prompt_tokens_details) and (
             tpd := total_usage.prompt_tokens_details
         ):

--- a/tests/llm/test_openai/test_predicted_outputs.py
+++ b/tests/llm/test_openai/test_predicted_outputs.py
@@ -1,0 +1,34 @@
+import instructor
+
+def test_predicted_outputs(client):
+    client = instructor.patch(client, mode=instructor.Mode.TOOLS)
+
+    # example from the openai docs for predicted outputs - https://platform.openai.com/docs/guides/predicted-outputs
+    code = """
+class User {
+  firstName: string = "";
+  lastName: string = "";
+  username: string = "";
+}
+
+export default User;
+"""
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": 'Replace the "username" property with an "email" property. Respond only with code, and with no markdown formatting.',
+            },
+            {
+                "role" : "user",
+                "content" : code
+            }
+        ],
+        prediction={
+            "content": "string",
+            "type": "content",
+        },
+    )
+    assert response.usage.completion_tokens_details.accepted_prediction_tokens is not None
+    assert response.usage.completion_tokens_details.rejected_prediction_tokens is not None


### PR DESCRIPTION
#1145 is trivially supported by instructor (since we just pass on the kwargs to the openai endpoint). This PR bubbles up predicted tokens details in the total usage in `update_total_usage` from the response which can be useful for callers.

Also added a test to demonstrate the correct behaviour
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tracking of predicted tokens in `update_total_usage` and test in `test_predicted_outputs.py`.
> 
>   - **Behavior**:
>     - `update_total_usage` in `utils.py` now tracks `accepted_prediction_tokens` and `rejected_prediction_tokens` from `completion_tokens_details`.
>   - **Testing**:
>     - New test `test_predicted_outputs` in `test_predicted_outputs.py` verifies tracking of predicted tokens in response usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 3f38122b68ab13fffabb3e773f6cc1985a51d1e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->