### PR TITLE
Adding cost for text-embedding-ada-002-v2

### DIFF
--- a/instructor/cli/usage.py
+++ b/instructor/cli/usage.py
@@ -74,6 +74,7 @@ MODEL_COSTS = {
     "text-embedding-3-small": 0.00002 / 1000,
     "text-embedding-3-large": 0.00013 / 1000,
     "text-embedding-ada-002": 0.00010 / 1000,
+    "text-embedding-ada-002-v2": 0.00010 / 1000,
 }
 
 


### PR DESCRIPTION
The cost for this model was missing from the usage.py file so I added it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add cost entry for `text-embedding-ada-002-v2` in `usage.py` with a rate of 0.00010 per 1000 units.
> 
>   - **Behavior**:
>     - Add cost entry for `text-embedding-ada-002-v2` in `usage.py` with a rate of 0.00010 per 1000 units.
>   - **Misc**:
>     - Aligns `text-embedding-ada-002-v2` cost with `text-embedding-ada-002`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 56d43bee4dc9f7c6e80a04a7d90c1de8c90c47ed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->