### PR TITLE
Add support for OpenRouter SO

### DIFF
--- a/instructor/client.py
+++ b/instructor/client.py
@@ -508,6 +508,7 @@ def from_openai(
             instructor.Mode.TOOLS,
             instructor.Mode.JSON,
             instructor.Mode.JSON_SCHEMA,
+            instructor.Mode.JSON_SCHEMA_OPENROUTER,
             instructor.Mode.MD_JSON,
         }
 

--- a/instructor/dsl/iterable.py
+++ b/instructor/dsl/iterable.py
@@ -104,6 +104,7 @@ class IterableBase:
                         Mode.JSON,
                         Mode.MD_JSON,
                         Mode.JSON_SCHEMA,
+                        Mode.JSON_SCHEMA_OPENROUTER,
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                     }:
@@ -145,6 +146,7 @@ class IterableBase:
                         Mode.JSON,
                         Mode.MD_JSON,
                         Mode.JSON_SCHEMA,
+                        Mode.JSON_SCHEMA_OPENROUTER,
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                     }:

--- a/instructor/dsl/partial.py
+++ b/instructor/dsl/partial.py
@@ -268,6 +268,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.JSON,
                         Mode.MD_JSON,
                         Mode.JSON_SCHEMA,
+                        Mode.JSON_SCHEMA_OPENROUTER,
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                     }:
@@ -309,6 +310,7 @@ class PartialBase(Generic[T_Model]):
                         Mode.JSON,
                         Mode.MD_JSON,
                         Mode.JSON_SCHEMA,
+                        Mode.JSON_SCHEMA_OPENROUTER,
                         Mode.CEREBRAS_JSON,
                         Mode.FIREWORKS_JSON,
                     }:

--- a/instructor/function_calls.py
+++ b/instructor/function_calls.py
@@ -158,6 +158,7 @@ class OpenAISchema(BaseModel):
         if mode in {
             Mode.JSON,
             Mode.JSON_SCHEMA,
+            Mode.JSON_SCHEMA_OPENROUTER,
             Mode.MD_JSON,
             Mode.JSON_O1,
             Mode.CEREBRAS_JSON,

--- a/instructor/mode.py
+++ b/instructor/mode.py
@@ -13,6 +13,7 @@ class Mode(enum.Enum):
     JSON_O1 = "json_o1"
     MD_JSON = "markdown_json_mode"
     JSON_SCHEMA = "json_schema_mode"
+    JSON_SCHEMA_OPENROUTER = "json_schema_openrouter"
     ANTHROPIC_TOOLS = "anthropic_tools"
     ANTHROPIC_JSON = "anthropic_json"
     COHERE_TOOLS = "cohere_tools"

--- a/instructor/process_response.py
+++ b/instructor/process_response.py
@@ -304,6 +304,11 @@ def handle_json_modes(
             "type": "json_object",
             "schema": response_model.model_json_schema(),
         }
+    elif mode == Mode.JSON_SCHEMA_OPENROUTER:
+        new_kwargs["response_format"] = {
+            "type": "json_schema",
+            "schema": response_model.model_json_schema(),
+        }
     elif mode == Mode.MD_JSON:
         new_kwargs["messages"].append(
             {
@@ -731,6 +736,7 @@ def handle_response_model(
         Mode.JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON),  # type: ignore
         Mode.MD_JSON: lambda rm, nk: handle_json_modes(rm, nk, Mode.MD_JSON),  # type: ignore
         Mode.JSON_SCHEMA: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON_SCHEMA),  # type: ignore
+        Mode.JSON_SCHEMA_OPENROUTER: lambda rm, nk: handle_json_modes(rm, nk, Mode.JSON_SCHEMA_OPENROUTER),  # type: ignore
         Mode.ANTHROPIC_TOOLS: handle_anthropic_tools,
         Mode.ANTHROPIC_JSON: handle_anthropic_json,
         Mode.COHERE_JSON_SCHEMA: handle_cohere_json_schema,


### PR DESCRIPTION
Hi, recently found your tool and I really like it.

I mainly use openrouter so I was a bit confused when using the `from_openai` client I got errors on some models. 

I looked at the code and saw that I had to enable another mod: `JSON`, `JSON_SCHEMA` or `MD_JSON`. However, none of these mods are used in any of these 

```json
response_format: {
      type: ``json_schema'',
      json_schema: {}
}
```

So according to the documentation from [OpenAI ](https://platform.openai.com/docs/guides/structured-outputs) and [Openrouter ](https://openrouter.ai/docs/features/structured-outputs) I implemented a new mod that uses ``json_schema``
This allowed to use almost all models in Openrouter.

I am still new to SO posture so I might have missed something, I will be glad if you can point out possible errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `JSON_SCHEMA_OPENROUTER` mode to support OpenRouter's JSON schema format across various functions and files.
> 
>   - **Behavior**:
>     - Adds `JSON_SCHEMA_OPENROUTER` mode to support OpenRouter's JSON schema format.
>     - Updates `from_openai()` in `client.py` to include `JSON_SCHEMA_OPENROUTER` in supported modes.
>   - **Functions**:
>     - Updates `extract_json()` and `extract_json_async()` in `iterable.py` and `partial.py` to handle `JSON_SCHEMA_OPENROUTER`.
>     - Modifies `from_response()` in `function_calls.py` to parse `JSON_SCHEMA_OPENROUTER` mode.
>     - Updates `handle_json_modes()` in `process_response.py` to handle `JSON_SCHEMA_OPENROUTER`.
>   - **Enums**:
>     - Adds `JSON_SCHEMA_OPENROUTER` to `Mode` enum in `mode.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 8af3ed5b04fe1930b3bb6b03623d5506df008dad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->