### PR TITLE
feat: add citation information to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,20 @@ We also provide some added CLI functionality for easy convenience:
 
 This project is licensed under the terms of the MIT License.
 
+## Citation
+
+If you use Instructor in your research, please cite it using the following BibTeX:
+
+```bibtex
+@software{liu2024instructor,
+  author = {Jason Liu and Contributors},
+  title = {Instructor: A library for structured outputs from large language models},
+  url = {https://github.com/instructor-ai/instructor},
+  year = {2024},
+  month = {3}
+}
+```
+
 # Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,20 @@ _Structured outputs powered by llms. Designed for simplicity, transparency, and 
 [![Discord](https://img.shields.io/discord/1192334452110659664?label=discord)](https://discord.gg/bD9YE9JArw)
 [![Downloads](https://img.shields.io/pypi/dm/instructor.svg)](https://pypi.python.org/pypi/instructor)
 
+## Citation
+
+If you use Instructor in your research or project, please cite it using:
+
+```bibtex
+@software{liu2024instructor,
+  author = {Jason Liu and Contributors},
+  title = {Instructor: A library for structured outputs from large language models},
+  url = {https://github.com/instructor-ai/instructor},
+  year = {2024},
+  month = {3}
+}
+```
+
 Instructor makes it easy to get structured data like JSON from LLMs like GPT-3.5, GPT-4, GPT-4-Vision, and open-source models including [Mistral/Mixtral](./integrations/together.md), [Ollama](./integrations/ollama.md), and [llama-cpp-python](./integrations/llama-cpp-python.md).
 
 It stands out for its simplicity, transparency, and user-centric design, built on top of Pydantic. Instructor helps you manage [validation context](./concepts/reask_validation.md), retries with [Tenacity](./concepts/retrying.md), and streaming [Lists](./concepts/lists.md) and [Partial](./concepts/partial.md) responses.


### PR DESCRIPTION
Added BibTeX citation format for academic references. Added citation section to both README.md and docs/index.md. Consistent citation format across documentation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds BibTeX citation information to `README.md` and `docs/index.md` for consistent academic referencing.
> 
>   - **Documentation**:
>     - Added a citation section with BibTeX format to `README.md` and `docs/index.md`.
>     - Ensures consistent citation format across documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 9d1dc18511578a00e20af37765ec9b14b7ae1d66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->