### PR TITLE
Updated SQL Model Example Docs for using SkipJsonSchema

### DIFF
--- a/docs/examples/sqlmodel.md
+++ b/docs/examples/sqlmodel.md
@@ -5,7 +5,11 @@ description: Learn how to integrate Instructor with SQLModel for seamless databa
 
 # Integrating Instructor with SQLModel
 
-[SQLModel](https://sqlmodel.tiangolo.com/) is a library designed for interacting with SQL databases from Python code using Python objects. `SQLModel` is based on `Pydantic` and `SQLAlchemy` and was created by [tiangolo](https://twitter.com/tiangolo) who also developed `FastAPI`. So you can expect seamless integration across all these libraries, reducing code duplicating and improving your developer experience. 
+[SQLModel](https://sqlmodel.tiangolo.com/) is a library designed for interacting with SQL databases from Python code using Python objects. 
+
+`SQLModel` is based on `Pydantic` and `SQLAlchemy` and was created by [tiangolo](https://twitter.com/tiangolo) who also developed `FastAPI`. 
+
+So you can expect seamless integration across all these libraries, reducing code duplicating and improving your developer experience. 
 
 # Example: Adding responses from Instructor directly to your DB
 
@@ -19,16 +23,64 @@ First we'll define a model that will serve as a table for our database and the s
 
 ```python
 from typing import Optional
+from uuid import UUID, uuid4
+from pydantic.json_schema import SkipJsonSchema
 from sqlmodel import Field, SQLModel
 import instructor
 
 
 class Hero(SQLModel, instructor.OpenAISchema, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: SkipJsonSchema[UUID] = Field(default_factory=lambda: uuid4(), primary_key=True)
     name: str
     secret_name: str
     age: Optional[int] = None
 ```
+
+### The Importance of Using SkipJsonSchema
+
+Notice the use of `SkipJsonSchema` for the `id` field. 
+
+This prunes the field from the JSON schema sent to the LLM, so it won't try to generate a UUID.
+
+When Instructor unpacks the response and loads it into the Hero model, it will automatically generate a UUID using the default_factory.
+    
+This approach saves tokens during LLM generation and more importantly protects against errors that might occur if the LLM generates an incorrect UUID format. 
+
+The resulting JSON schema sent to the LLM will look like:
+
+```json
+{
+    "properties": {
+        "name": {
+            "title": "Name",
+            "type": "string"
+        },
+        "secret_name": {
+            "title": "Secret Name",
+            "type": "string"
+        },
+        "age": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Age"
+        }
+    },
+    "required": [
+        "name",
+        "secret_name"
+    ],
+    "title": "Hero",
+    "type": "object"
+}
+```
+
 
 ## Generating a record
 
@@ -40,12 +92,14 @@ from openai import OpenAI
 
 # <%hide%>
 from typing import Optional
+from uuid import UUID, uuid4
+from pydantic.json_schema import SkipJsonSchema
 from sqlmodel import Field, SQLModel
 
 
 class Hero(SQLModel, instructor.OpenAISchema, table=True):
     __table_args__ = {'extend_existing': True}
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: SkipJsonSchema[UUID] = Field(default_factory=lambda: uuid4(), primary_key=True)
     name: str
     secret_name: str
     age: Optional[int] = None
@@ -73,12 +127,14 @@ def create_hero() -> Hero:
 import instructor
 from openai import OpenAI
 from typing import Optional
+from uuid import UUID, uuid4
+from pydantic.json_schema import SkipJsonSchema
 from sqlmodel import Field, SQLModel, create_engine, Session
 
 
 class Hero(SQLModel, instructor.OpenAISchema, table=True):
     __table_args__ = {'extend_existing': True}
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: SkipJsonSchema[UUID] = Field(default_factory=lambda: uuid4(), primary_key=True)
     name: str
     secret_name: str
     age: Optional[int] = None
@@ -102,8 +158,14 @@ engine = create_engine("sqlite:///database.db")
 SQLModel.metadata.create_all(engine)
 
 hero = create_hero()
+
+# The Raw Response from the LLM will not have an id due to the SkipJsonSchema
+print(hero._raw_response.choices[0].message.content)
+#> {'name': 'Superman', 'secret_name': 'Clark Kent', 'age': 30}
+
+# The model_dump() method will include the generated id as it has been loaded as a Hero object
 print(hero.model_dump())
-#> {'name': 'Superman', 'secret_name': 'Clark Kent', 'age': 30, 'id': None}
+#> {'name': 'Superman', 'secret_name': 'Clark Kent', 'age': 30, 'id': UUID('1234-5678-...')}
 
 with Session(engine) as session:
     session.add(hero)


### PR DESCRIPTION
A problem with using SQL Model is sometimes even with the id set to optional it will try to generate the id.

This is especially problematic with UUIDs as the LLM will incorrectly generate these a non negligible amount of the time.

Using SkipJsonSchema on the ID field prune this field from the json schema sent to the LLM as the response model, thus resulting in the model not even attempting to generate the id.

Then once instructor unpacks the response as the specified model, we can generate the UUID by having a factory default of uuid.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated SQLModel example docs to use `SkipJsonSchema` for UUIDs, preventing LLM-generated IDs.
> 
>   - **Behavior**:
>     - Updated `Hero` model in `sqlmodel.md` to use `SkipJsonSchema[UUID]` for `id` field, preventing LLM from generating UUIDs.
>     - `id` is now generated using `default_factory=uuid4()`.
>   - **Documentation**:
>     - Added explanation of `SkipJsonSchema` usage and its benefits in `sqlmodel.md`.
>     - Included JSON schema example showing pruned `id` field.
>     - Updated code examples to reflect changes in `Hero` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 36f702235e9f3ebdbbe1b5f6eecf1a0a3414be90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->