### PR TITLE
feat: add mistral PDF support

### DIFF
--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -241,7 +241,9 @@ print(resp)
 
 ## `PDF`
 
-The `Audio` class represents an audio file that can be loaded from a URL or file path. It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
+The `PDF` class represents a PDF file that can be loaded from a URL or file path.
+
+It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
 
 ### Usage
 

--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -12,7 +12,7 @@ description: Learn how the Image and Audio class in Instructor enables seamless 
 > - (PDF) : A sample PDF file which contains a fake invoice [invoice.pdf](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf)
 >   Instructor provides a unified, provider-agnostic interface for working with multimodal inputs like images and PDFs.
 
-structor provides a unified, provider-agnostic interface for working with multimodal inputs like images, PDFs, and audio files. With Instructor's multimodal objects, you can easily load media from URLs, local files, or base64 strings using a consistent API that works across different AI providers (OpenAI, Anthropic, Mistral, etc.).
+Instructor provides a unified, provider-agnostic interface for working with multimodal inputs like images, PDFs, and audio files. With Instructor's multimodal objects, you can easily load media from URLs, local files, or base64 strings using a consistent API that works across different AI providers (OpenAI, Anthropic, Mistral, etc.).
 
 Instructor handles all the provider-specific formatting requirements behind the scenes, ensuring your code remains clean and future-proof as provider APIs evolve.
 

--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -5,7 +5,18 @@ description: Learn how the Image and Audio class in Instructor enables seamless 
 
 # Multimodal
 
-Instructor supports multimodal interactions by providing helper classes that are automatically converted to the correct format for different providers, allowing you to work with both text and images in your prompts and responses. This functionality is implemented in the `multimodal.py` module and provides a seamless way to handle images alongside text for various AI models.
+> We've provided a few different sample files for you to use to test out these new features. All examples below use these files.
+>
+> - (Image) : An image of some blueberry plants [image.jpg](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg)
+> - (Audio) : A Recording of the Original Gettysburg Address : [gettysburg.wav](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav)
+> - (PDF) : A sample PDF file which contains a fake invoice [invoice.pdf](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf)
+>   Instructor provides a unified, provider-agnostic interface for working with multimodal inputs like images and PDFs.
+
+structor provides a unified, provider-agnostic interface for working with multimodal inputs like images, PDFs, and audio files. With Instructor's multimodal objects, you can easily load media from URLs, local files, or base64 strings using a consistent API that works across different AI providers (OpenAI, Anthropic, Mistral, etc.).
+
+Instructor handles all the provider-specific formatting requirements behind the scenes, ensuring your code remains clean and future-proof as provider APIs evolve.
+
+Let's see how to use the Image, Audio and PDF classes.
 
 ## `Image`
 
@@ -72,22 +83,23 @@ print(response.model_dump_json())
 """
 {"description":"A tray filled with several blueberry muffins, with one muffin prominently in the foreground. The muffins have a golden-brown top and are surrounded by a beige paper liners. Some muffins are partially visible, and fresh blueberries are scattered around the tray.", "objects": ["muffins", "blueberries", "tray", "paper liners"], "colors": ["golden-brown", "blue", "beige"], "text": null}
 """
+```
 
 With autodetect_images=True, you can directly provide URLs or file paths
 response = client.chat.completions.create(
-    model="gpt-4o-mini",
-    response_model=ImageAnalyzer,
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                "What is in this two images?",
-                "https://static01.nyt.com/images/2017/04/14/dining/14COOKING-RITZ-MUFFINS/14COOKING-RITZ-MUFFINS-jumbo.jpg",
-                "muffin.jpg",  # Using the file we downloaded in the previous example
-            ],
-        }
-    ],
-    autodetect_images=True,
+model="gpt-4o-mini",
+response_model=ImageAnalyzer,
+messages=[
+{
+"role": "user",
+"content": [
+"What is in this two images?",
+"https://static01.nyt.com/images/2017/04/14/dining/14COOKING-RITZ-MUFFINS/14COOKING-RITZ-MUFFINS-jumbo.jpg",
+"muffin.jpg", # Using the file we downloaded in the previous example
+],
+}
+],
+autodetect_images=True,
 )
 
 print(response.model_dump_json())
@@ -98,10 +110,13 @@ print(response.model_dump_json())
 By leveraging Instructor's multimodal capabilities, you can focus on building your application logic without worrying about the intricacies of each provider's image handling format. This not only saves development time but also makes your code more maintainable and adaptable to future changes in AI provider APIs.
 
 ### Anthropic Prompt Caching
+
 Instructor supports Anthropic prompt caching with images. To activate prompt caching, you can pass image content as a dictionary of the form
+
 ```python
 {"type": "image", "source": <path_or_url_or_base64_encoding>, "cache_control": True}
 ```
+
 and set `autodetect_images=True`, or flag it within a constructor such as `instructor.Image.from_path("path/to/image.jpg", cache_control=True)`. For example:
 
 ```python
@@ -165,6 +180,8 @@ print(response.model_dump_json())
 {"description":"A tray of freshly baked blueberry muffins with golden-brown tops in paper liners.", "objects":["muffins","blueberries","tray","paper liners"], "colors":["golden-brown","blue","beige"], "text":null}
 """
 
+```
+
 ## `Audio`
 
 The `Audio` class represents an audio file that can be loaded from a URL or file path. It provides methods to create `Audio` instances but currently only OpenAI supports it. You can create an instance using the `from_path` and `from_url` methods. The `Audio` class will automatically convert it to a base64-encoded image and include it in the API request.
@@ -220,4 +237,46 @@ resp = client.chat.completions.create(
 
 print(resp)
 #> name='Jason' age=20
+```
+
+## `PDF`
+
+The `Audio` class represents an audio file that can be loaded from a URL or file path. It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
+
+### Usage
+
+```python
+ from openai import OpenAI
+ import instructor
+ from pydantic import BaseModel
+ from instructor.multimodal import PDF
+
+ # Set up the client
+ url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
+ client = instructor.from_openai(OpenAI())
+
+
+ # Create a model for analyzing PDFs
+ class Invoice(BaseModel):
+     total: float
+     items: list[str]
+
+
+ # Load and analyze a PDF
+ response = client.chat.completions.create(
+     model="gpt-4o-mini",
+     response_model=Invoice,
+     messages=[
+         {
+             "role": "user",
+             "content": [
+                 "Analyze this document",
+                 PDF.from_url(url),
+             ],
+         }
+     ],
+ )
+
+ print(response)
+ # > Total = 220, items = ['English Tea', 'Tofu']
 ```

--- a/docs/integrations/mistral.md
+++ b/docs/integrations/mistral.md
@@ -359,7 +359,7 @@ response = client.chat.completions.create(
                 "Extract out the total and line items from the invoice",
                 PDF.from_url(
                     url
-                ),  # Also supports PDF.from_file() and PDF.from_base64()
+                ),  # Also supports PDF.from_path() and PDF.from_base64()
             ],
         },
     ],

--- a/docs/integrations/mistral.md
+++ b/docs/integrations/mistral.md
@@ -294,7 +294,7 @@ async def stream_partial():
             {"role": "user", "content": "Jason Liu is 25 years old"},
         ],
     )
-    
+
     async for partial_user in model:
         print(f"Received update: {partial_user}")
 
@@ -306,7 +306,7 @@ async def stream_iterable():
             {"role": "user", "content": "Make up two people"},
         ],
     )
-    
+
     async for user in users:
         print(f"Generated user: {user}")
 
@@ -326,3 +326,45 @@ asyncio.run(stream_iterable())
 ## Updates and Compatibility
 
 Instructor maintains compatibility with the latest Mistral API versions and models. Check the [changelog](https://github.com/jxnl/instructor/blob/main/CHANGELOG.md) for updates on Mistral integration features.
+
+## Multimodal
+
+Instructor makes it easy to analyse and extract semantic information from PDFs using Mistral's models. Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method. Note that for now Mistral only supports document URLs.
+
+```
+from instructor.multimodal import PDF
+from pydantic import BaseModel
+import instructor
+from mistralai import Mistral
+import os
+
+
+class Receipt(BaseModel):
+    total: int
+    items: list[str]
+
+
+client = instructor.from_mistral(Mistral(os.environ["MISTRAL_API_KEY"]))
+
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
+
+response = client.chat.completions.create(
+    model="ministral-8b-latest",
+    response_model=Receipt,
+    max_tokens=1000,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "Extract out the total and line items from the invoice",
+                PDF.from_url(
+                    url
+                ),  # Also supports PDF.from_file() and PDF.from_base64()
+            ],
+        },
+    ],
+)
+
+print(response)
+# > Receipt(total=220, items=['English Tea', 'Tofu'])
+```

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -154,6 +154,171 @@ print(user)
 #> }
 ```
 
+## Multimodal
+
+> We've provided a few different sample files for you to use to test out these new features. All examples below use these files.
+>
+> - (Audio) : A Recording of the Original Gettysburg Address : [gettysburg.wav](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav)
+> - (Image) : An image of some blueberry plants [image.jpg](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg)
+> - (PDF) : A sample PDF file which contains a fake invoice [invoice.pdf](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf)
+
+Instructor provides a unified, provider-agnostic interface for working with multimodal inputs like images, PDFs, and audio files. With Instructor's multimodal objects, you can easily load media from URLs, local files, or base64 strings using a consistent API that works across different AI providers (OpenAI, Anthropic, Mistral, etc.).
+
+Instructor handles all the provider-specific formatting requirements behind the scenes, ensuring your code remains clean and future-proof as provider APIs evolve.
+
+Let's see how to use the Image, Audio and PDF classes.
+
+### Image
+
+> For a more in-depth walkthrough of the Image component, check out the [docs here](../concepts/multimodal.md)
+
+Instructor makes it easy to analyse and extract semantic information from images using OpenAI's GPT-4o models. [Click here](https://platform.openai.com/docs/models) to check if the model you'd like to use has vision capabilities.
+
+Let's see an example below with the sample image above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_path` and the `from_base64` class methods.
+
+```python
+from instructor.multimodal import Image
+from pydantic import BaseModel, Field
+import instructor
+from openai import OpenAI
+
+
+class ImageDescription(BaseModel):
+    objects: list[str] = Field(..., description="The objects in the image")
+    scene: str = Field(..., description="The scene of the image")
+    colors: list[str] = Field(..., description="The colors in the image")
+
+
+client = instructor.from_openai(OpenAI())
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg"
+# Multiple ways to load an image:
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    response_model=ImageDescription,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "What is in this image?",
+                # Option 1: Direct URL with autodetection
+                Image.from_url(url),
+                # Option 2: Local file
+                # Image.from_path("path/to/local/image.jpg")
+                # Option 3: Base64 string
+                # Image.from_base64("base64_encoded_string_here")
+                # Option 4: Autodetect
+                # Image.autodetect(<url|path|base64>)
+            ],
+        },
+    ],
+)
+
+print(response)
+# Example output:
+# ImageDescription(
+#     objects=['blueberries', 'leaves'],
+#     scene='A blueberry bush with clusters of ripe blueberries and some unripe ones against a cloudy sky',
+#     colors=['green', 'blue', 'purple', 'white']
+# )
+```
+
+### PDF
+
+Instructor makes it easy to analyse and extract semantic information from PDFs using OpenAI's GPT-4o models.
+
+Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_path` and the `from_base64` class methods.
+
+```python
+from instructor.multimodal import PDF
+from pydantic import BaseModel, Field
+import instructor
+from openai import OpenAI
+
+
+class Receipt(BaseModel):
+    total: int
+    items: list[str]
+
+
+client = instructor.from_openai(OpenAI())
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
+# Multiple ways to load an PDF:
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    response_model=Receipt,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "Extract out the total and line items from the invoice",
+                # Option 1: Direct URL
+                PDF.from_url(url),
+                # Option 2: Local file
+                # PDF.from_path("path/to/local/invoice.pdf"),
+                # Option 3: Base64 string
+                # PDF.from_base64("base64_encoded_string_here")
+                # Option 4: Autodetect
+                # PDF.autodetect(<url|path|base64>)
+            ],
+        },
+    ],
+)
+
+print(response)
+# > Receipt(total=220, items=['English Tea', 'Tofu'])
+```
+
+### Audio
+
+Instructor makes it easy to analyse and extract semantic information from Audio files using OpenAI's GPT-4o models. Let's see an example below with the sample Audio file above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_path`
+
+```python
+from instructor.multimodal import Audio
+from pydantic import BaseModel
+import instructor
+from openai import OpenAI
+
+
+class AudioDescription(BaseModel):
+    transcript: str
+    summary: str
+    speakers: list[str]
+    key_points: list[str]
+
+
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav"
+
+client = instructor.from_openai(OpenAI())
+
+response = client.chat.completions.create(
+    model="gpt-4o-audio-preview",
+    response_model=AudioDescription,
+    modalities=["text"],
+    audio={"voice": "alloy", "format": "wav"},
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "Please transcribe and analyze this audio:",
+                # Multiple loading options:
+                Audio.from_url(url),
+                # Option 2: Local file
+                # Audio.from_path("path/to/local/audio.mp3")
+            ],
+        },
+    ],
+)
+
+print(response)
+# > transcript='Four score and seven years ago our fathers..."]
+```
+
 ## Streaming Support
 
 Instructor has two main ways that you can use to stream responses out

--- a/instructor/multimodal.py
+++ b/instructor/multimodal.py
@@ -370,6 +370,86 @@ class PDF(BaseModel):
     data: str | None = Field(None, description="Base64 encoded PDF data", repr=False)
 
     @classmethod
+    def autodetect(cls, source: str | Path) -> PDF:
+        """Attempt to autodetect a PDF from a source string or Path.
+        Args:
+            source (Union[str,path]): The source string or path.
+        Returns:
+            A PDF if the source is detected to be a valid PDF.
+        Raises:
+            ValueError: If the source is not detected to be a valid PDF.
+        """
+        if isinstance(source, str):
+            if cls.is_base64(source):
+                return cls.from_base64(source)
+            elif source.startswith(("http://", "https://")):
+                return cls.from_url(source)
+
+            try:
+                if Path(source).is_file():
+                    return cls.from_path(source)
+            except FileNotFoundError as err:
+                raise ValueError("PDF file not found") from err
+            except OSError as e:
+                if e.errno == 63:  # File name too long
+                    raise ValueError("PDF file name too long") from e
+                raise ValueError("Unable to read PDF file") from e
+
+            return cls.from_raw_base64(source)
+        elif isinstance(source, Path):
+            return cls.from_path(source)
+
+        raise ValueError("Unable to determine PDF type or unsupported PDF format")
+
+    @classmethod
+    def is_base64(cls, s: str) -> bool:
+        return bool(re.match(r"^data:application/pdf;base64,", s))
+
+    @classmethod
+    def from_base64(cls, data_uri: str) -> PDF:
+        header, encoded = data_uri.split(",", 1)
+        media_type = header.split(":")[1].split(";")[0]
+        if media_type not in VALID_PDF_MIME_TYPES:
+            raise ValueError(f"Unsupported PDF format: {media_type}")
+        return cls(
+            source=data_uri,
+            media_type=media_type,
+            data=encoded,
+        )
+
+    @classmethod
+    @lru_cache
+    def from_path(cls, path: str | Path) -> PDF:
+        path = Path(path)
+        if not path.is_file():
+            raise FileNotFoundError(f"PDF file not found: {path}")
+
+        if path.stat().st_size == 0:
+            raise ValueError("PDF file is empty")
+
+        media_type, _ = mimetypes.guess_type(str(path))
+        if media_type not in VALID_PDF_MIME_TYPES:
+            raise ValueError(f"Unsupported PDF format: {media_type}")
+
+        data = base64.b64encode(path.read_bytes()).decode("utf-8")
+        return cls(source=path, media_type=media_type, data=data)
+
+    @classmethod
+    def from_raw_base64(cls, data: str) -> PDF:
+        try:
+            decoded = base64.b64decode(data)
+            # Check if it's a valid PDF by looking for the PDF header
+            if decoded.startswith(b"%PDF-"):
+                return cls(
+                    source=data,
+                    media_type="application/pdf",
+                    data=data,
+                )
+            raise ValueError("Invalid PDF format")
+        except Exception as e:
+            raise ValueError("Invalid or unsupported base64 PDF data") from e
+
+    @classmethod
     @lru_cache
     def from_url(cls, url: str) -> PDF:
         parsed_url = urlparse(url)
@@ -398,6 +478,157 @@ class PDF(BaseModel):
             }
         raise ValueError("Mistral only supports document URLs for now")
 
+    def to_openai(self) -> dict[str, Any]:
+        """Convert to OpenAI's document format."""
+        if (
+            isinstance(self.source, str)
+            and self.source.startswith(("http://", "https://"))
+            and not self.data
+        ):
+            # Fetch the file from URL and convert to base64
+            data = requests.get(self.source)
+            data = base64.b64encode(data.content).decode("utf-8")
+            return {
+                "type": "file",
+                "file": {
+                    "filename": self.source,
+                    "file_data": f"data:{self.media_type};base64,{data}",
+                },
+            }
+        elif self.data or self.is_base64(str(self.source)):
+            data = self.data or str(self.source).split(",", 1)[1]
+            return {
+                "type": "file",
+                "file": {
+                    "filename": self.source
+                    if isinstance(self.source, str)
+                    else str(self.source),
+                    "file_data": f"data:{self.media_type};base64,{data}",
+                },
+            }
+        else:
+            raise ValueError("PDF data is missing for base64 encoding.")
+
+    def to_anthropic(self) -> dict[str, Any]:
+        """Convert to Anthropic's document format."""
+        if (
+            isinstance(self.source, str)
+            and self.source.startswith(("http://", "https://"))
+            and not self.data
+        ):
+            return {
+                "type": "document",
+                "source": {
+                    "type": "url",
+                    "url": self.source,
+                },
+            }
+        else:
+            if not self.data:
+                self.data = requests.get(str(self.source)).content
+                self.data = base64.b64encode(self.data).decode("utf-8")
+
+            return {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": self.media_type,
+                    "data": self.data,
+                },
+            }
+
+    def to_genai(self):
+        from google.genai import types
+
+        if (
+            isinstance(self.source, str)
+            and self.source.startswith(("http://", "https://"))
+            and not self.data
+        ):
+            # Fetch the file from URL and convert to base64
+            data = requests.get(self.source).content
+            data = base64.b64encode(data).decode("utf-8")
+            return types.Part.from_bytes(
+                data=base64.b64decode(data),
+                mime_type=self.media_type,
+            )
+
+        if self.data:
+            return types.Part.from_bytes(
+                data=base64.b64decode(self.data),
+                mime_type=self.media_type,
+            )
+
+        raise ValueError("Unsupported PDF format")
+
+
+class PDFWithCacheControl(PDF):
+    """PDF with Anthropic prompt caching support."""
+
+    def to_anthropic(self) -> dict[str, Any]:
+        """Override Anthropic return with cache_control."""
+        result = super().to_anthropic()
+        result["cache_control"] = {"type": "ephemeral"}
+        return result
+
+
+class PDFWithGenaiFile(PDF):
+    @classmethod
+    def from_new_genai_file(
+        cls, file_path: str, retry_delay: int = 10, max_retries: int = 20
+    ) -> PDFWithGenaiFile:
+        """Create a new PDFWithGenaiFile from a file path."""
+        from google.genai.types import FileState
+        import time
+        from google.genai import Client
+
+        client = Client()
+        file = client.files.upload(file=file_path)
+        while file.state != FileState.ACTIVE:
+            time.sleep(retry_delay)
+            file = client.files.get(name=file.name)
+            if max_retries > 0:
+                max_retries -= 1
+            else:
+                raise Exception(
+                    "Max retries reached. File upload has been started but is still pending"
+                )
+
+        return cls(source=file.uri, media_type=file.mime_type, data=None)  # type: ignore
+
+    @classmethod
+    def from_existing_genai_file(cls, file_name: str) -> PDFWithGenaiFile:
+        """Create a new PDFWithGenaiFile from a file URL."""
+        from google.genai import types
+        from google.genai.types import FileState
+        from google.genai import Client
+
+        client = Client()
+        file = client.files.get(name=file_name)
+        if file.source == types.FileSource.UPLOADED and file.state == FileState.ACTIVE:
+            return cls(
+                source=file.uri,  # type: ignore
+                media_type=file.mime_type,  # type: ignore
+                data=None,
+            )
+        else:
+            raise ValueError("We only support uploaded PDFs for now")
+
+    def to_genai(self):
+        from google.genai import types
+
+        if (
+            self.source
+            and isinstance(self.source, str)
+            and "https://generativelanguage.googleapis.com/v1beta/files/" in self.source
+        ):
+            return types.Part.from_uri(
+                file_uri=self.source,
+                mime_type=self.media_type,
+            )
+
+        return super().to_genai()
+
 
 def convert_contents(
     contents: Union[  # noqa: UP007
@@ -412,7 +643,7 @@ def convert_contents(
     """Convert content items to the appropriate format based on the specified mode."""
     if isinstance(contents, str):
         return contents
-    if isinstance(contents, (Image, Audio)) or isinstance(contents, dict):
+    if isinstance(contents, (Image, Audio, PDF)) or isinstance(contents, dict):
         contents = [contents]
 
     converted_contents: list[dict[str, Union[str, Image]]] = []  # noqa: UP007
@@ -433,7 +664,7 @@ def convert_contents(
             elif mode in {
                 Mode.MISTRAL_STRUCTURED_OUTPUTS,
                 Mode.MISTRAL_TOOLS,
-            } and isinstance(content, PDF):
+            } and isinstance(content, (PDF)):
                 converted_contents.append(content.to_mistral())  # type: ignore
             else:
                 converted_contents.append(content.to_openai())
@@ -541,6 +772,8 @@ def extract_genai_multimodal_content(
             if content_part.text and autodetect_images:
                 # Detect if the text is an image
                 converted_item = Image.autodetect_safely(content_part.text)
+
+                # We only do autodetection for images for now
                 if isinstance(converted_item, Image):
                     converted_contents.append(converted_item.to_genai())
                     continue

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from instructor.multimodal import Image, Audio
+from instructor.multimodal import PDF, Image, Audio
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (
     ChatCompletion,
@@ -968,7 +968,7 @@ def convert_to_genai_messages(
                 for content_item in message["content"]:
                     if isinstance(content_item, str):
                         content_parts.append(types.Part.from_text(text=content_item))
-                    elif isinstance(content_item, (Image, Audio)):
+                    elif isinstance(content_item, (Image, Audio, PDF)):
                         content_parts.append(content_item.to_genai())
                     else:
                         raise ValueError(

--- a/tests/llm/test_genai/test_multimodal.py
+++ b/tests/llm/test_genai/test_multimodal.py
@@ -3,6 +3,7 @@ import pytest
 from pydantic import BaseModel
 import os
 from .util import models, modes
+import base64
 
 
 class ImageDescription(BaseModel):
@@ -13,6 +14,12 @@ curr_file = os.path.dirname(__file__)
 image_file = os.path.join(curr_file, "../../assets/image.jpg")
 audio_file = os.path.join(curr_file, "../../assets/gettysburg.wav")
 audio_url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav"
+
+pdf_path = os.path.join(curr_file, "../../assets/invoice.pdf")
+
+
+pdf_base64 = base64.b64encode(open(pdf_path, "rb").read()).decode("utf-8")
+pdf_base64_string = f"data:application/pdf;base64,{pdf_base64}"
 
 
 long_message = """
@@ -227,3 +234,103 @@ async def test_autodetect_images_async(client, model, mode, autodetect_images):
     )
 
     assert autodetect_images == response
+
+
+class Invoice(BaseModel):
+    total: float
+    items: list[str]
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("pdf_source", [pdf_path, pdf_base64_string])
+def test_local_pdf(client, model, mode, pdf_source):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDF.autodetect(pdf_source),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+def test_existing_genai_file_pdf_integration(client, model, mode):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.from_new_genai_file(
+                        pdf_path
+                    ),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+def test_upload_file_genai_pdf_integration(client, model, mode):
+    client = instructor.from_genai(client, mode=mode)
+    file = client.files.upload(file=pdf_path)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.from_existing_genai_file(
+                        file.name
+                    ),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("pdf_source", [pdf_path, pdf_base64_string])
+def test_local_pdf_with_genai_file(client, model, mode, pdf_source):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.autodetect(pdf_source),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2

--- a/tests/llm/test_mistral/test_multimodal.py
+++ b/tests/llm/test_mistral/test_multimodal.py
@@ -1,0 +1,54 @@
+import pytest
+from pydantic import BaseModel
+import instructor
+from .util import modes, models
+
+pdf_url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
+
+
+class Invoice(BaseModel):
+    total: float
+    items: list[str]
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("model", models)
+def test_mistral_retry_validation(client, model, mode):
+    client = instructor.from_mistral(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "Extract information from the invoice.",
+                    instructor.multimodal.PDF.from_url(pdf_url),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("model", models)
+@pytest.mark.asyncio
+async def test_mistral_retry_validation_async(client, model, mode):
+    client = instructor.from_mistral(client, mode=mode, use_async=True)
+    response = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "Extract information from the invoice.",
+                    instructor.multimodal.PDF.from_url(pdf_url),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert response.total == 220
+    assert len(response.items) == 2


### PR DESCRIPTION
This PR adds support for PDF parsing with Mistral. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add PDF parsing support for Mistral, including new `PDF` class and documentation updates.
> 
>   - **Behavior**:
>     - Adds PDF parsing support with Mistral in `multimodal.py`.
>     - Introduces `PDF` class with methods `from_url()` and `to_mistral()`.
>     - Updates `convert_contents()` to handle `PDF` for Mistral modes.
>   - **Documentation**:
>     - Updates `multimodal.md` and `mistral.md` to include PDF usage examples.
>   - **Tests**:
>     - Adds `test_multimodal.py` to test PDF parsing with Mistral in both sync and async modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for dd460fdec24e9d1cff86d417d051293021d335c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->