### PR TITLE
Feat/add openai pdf

### DIFF
--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -241,7 +241,7 @@ print(resp)
 
 ## `PDF`
 
-The `PDF` class represents an PDF file that can be loaded from a URL or file path.
+The `PDF` class represents a PDF file that can be loaded from a URL or file path.
 
 It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
 

--- a/docs/concepts/multimodal.md
+++ b/docs/concepts/multimodal.md
@@ -241,7 +241,9 @@ print(resp)
 
 ## `PDF`
 
-The `Audio` class represents an audio file that can be loaded from a URL or file path. It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
+The `PDF` class represents an PDF file that can be loaded from a URL or file path.
+
+It provides methods to create `PDF` instances and is currently supported for OpenAI, Mistral, GenAI and Anthropic client integrations.
 
 ### Usage
 

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -208,6 +208,8 @@ response = client.chat.completions.create(
                 # Image.from_path("path/to/local/image.jpg")
                 # Option 3: Base64 string
                 # Image.from_base64("base64_encoded_string_here")
+                # Option 4: Autodetect
+                # Image.autodetect(<url|path|base64>)
             ],
         },
     ],
@@ -259,6 +261,8 @@ response = client.chat.completions.create(
                 # PDF.from_path("path/to/local/invoice.pdf"),
                 # Option 3: Base64 string
                 # PDF.from_base64("base64_encoded_string_here")
+                # Option 4: Autodetect
+                # PDF.autodetect(<url|path|base64>)
             ],
         },
     ],

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -154,6 +154,167 @@ print(user)
 #> }
 ```
 
+## Multimodal
+
+> We've provided a few different sample files for you to use to test out these new features. All examples below use these files.
+>
+> - (Audio) : A Recording of the Original Gettysburg Address : [gettysburg.wav](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav)
+> - (Image) : An image of some blueberry plants [image.jpg](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg)
+> - (PDF) : A sample PDF file which contains a fake invoice [invoice.pdf](https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf)
+
+Instructor provides a unified, provider-agnostic interface for working with multimodal inputs like images, PDFs, and audio files. With Instructor's multimodal objects, you can easily load media from URLs, local files, or base64 strings using a consistent API that works across different AI providers (OpenAI, Anthropic, Mistral, etc.).
+
+Instructor handles all the provider-specific formatting requirements behind the scenes, ensuring your code remains clean and future-proof as provider APIs evolve.
+
+Let's see how to use the Image, Audio and PDF classes.
+
+### Image
+
+> For a more in-depth walkthrough of the Image component, check out the [docs here](../concepts/multimodal.md)
+
+Instructor makes it easy to analyse and extract semantic information from images using OpenAI's GPT-4o models. [Click here](https://platform.openai.com/docs/models) to check if the model you'd like to use has vison capabilities.
+
+Let's see an example below with the sample image above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_file` and the `from_base64` class methods.
+
+```python
+from instructor.multimodal import Image
+from pydantic import BaseModel, Field
+import instructor
+from openai import OpenAI
+
+
+class ImageDescription(BaseModel):
+    objects: list[str] = Field(..., description="The objects in the image")
+    scene: str = Field(..., description="The scene of the image")
+    colors: list[str] = Field(..., description="The colors in the image")
+
+
+client = instructor.from_openai(OpenAI())
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/image.jpg"
+# Multiple ways to load an image:
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    response_model=ImageDescription,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "What is in this image?",
+                # Option 1: Direct URL with autodetection
+                Image.from_url(url),
+                # Option 2: Local file
+                # Image.from_file("path/to/local/image.jpg")
+                # Option 3: Base64 string
+                # Image.from_base64("base64_encoded_string_here")
+            ],
+        },
+    ],
+)
+
+print(response)
+# Example output:
+# ImageDescription(
+#     objects=['blueberries', 'leaves'],
+#     scene='A blueberry bush with clusters of ripe blueberries and some unripe ones against a cloudy sky',
+#     colors=['green', 'blue', 'purple', 'white']
+# )
+```
+
+### PDF
+
+Instructor makes it easy to analyse and extract semantic information from PDFs using OpenAI's GPT-4o models.
+
+Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_file` and the `from_base64` class methods.
+
+```python
+from instructor.multimodal import PDF
+from pydantic import BaseModel, Field
+import instructor
+from openai import OpenAI
+
+
+class Receipt(BaseModel):
+    total: int
+    items: list[str]
+
+
+client = instructor.from_openai(OpenAI())
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/invoice.pdf"
+# Multiple ways to load an PDF:
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    response_model=Receipt,
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "Extract out the total and line items from the invoice",
+                # Option 1: Direct URL
+                PDF.from_url(url),
+                # Option 2: Local file
+                # PDF.from_file("path/to/local/invoice.pdf"),
+                # Option 3: Base64 string
+                # PDF.from_base64("base64_encoded_string_here")
+            ],
+        },
+    ],
+)
+
+print(response)
+# > Receipt(total=220, items=['English Tea', 'Tofu'])
+```
+
+### Audio
+
+Instructor makes it easy to analyse and extract semantic information from Audio files using OpenAI's GPT-4o models. Let's see an example below with the sample Audio file above where we'll load it in using our `from_url` method.
+
+Note that we support local files and base64 strings too with the `from_path`
+
+```python
+from instructor.multimodal import Audio
+from pydantic import BaseModel
+import instructor
+from openai import OpenAI
+
+
+class AudioDescription(BaseModel):
+    transcript: str
+    summary: str
+    speakers: list[str]
+    key_points: list[str]
+
+
+url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav"
+
+client = instructor.from_openai(OpenAI())
+
+response = client.chat.completions.create(
+    model="gpt-4o-audio-preview",
+    response_model=AudioDescription,
+    modalities=["text"],
+    audio={"voice": "alloy", "format": "wav"},
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                "Please transcribe and analyze this audio:",
+                # Multiple loading options:
+                Audio.from_url(url),
+                # Option 2: Local file
+                # Audio.from_path("path/to/local/audio.mp3")
+            ],
+        },
+    ],
+)
+
+print(response)
+# > transcript='Four score and seven years ago our fathers..."]
+```
+
 ## Streaming Support
 
 Instructor has two main ways that you can use to stream responses out

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -176,7 +176,7 @@ Instructor makes it easy to analyse and extract semantic information from images
 
 Let's see an example below with the sample image above where we'll load it in using our `from_url` method.
 
-Note that we support local files and base64 strings too with the `from_file` and the `from_base64` class methods.
+Note that we support local files and base64 strings too with the `from_path` and the `from_base64` class methods.
 
 ```python
 from instructor.multimodal import Image
@@ -205,7 +205,7 @@ response = client.chat.completions.create(
                 # Option 1: Direct URL with autodetection
                 Image.from_url(url),
                 # Option 2: Local file
-                # Image.from_file("path/to/local/image.jpg")
+                # Image.from_path("path/to/local/image.jpg")
                 # Option 3: Base64 string
                 # Image.from_base64("base64_encoded_string_here")
             ],
@@ -228,7 +228,7 @@ Instructor makes it easy to analyse and extract semantic information from PDFs u
 
 Let's see an example below with the sample PDF above where we'll load it in using our `from_url` method.
 
-Note that we support local files and base64 strings too with the `from_file` and the `from_base64` class methods.
+Note that we support local files and base64 strings too with the `from_path` and the `from_base64` class methods.
 
 ```python
 from instructor.multimodal import PDF

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -172,7 +172,7 @@ Let's see how to use the Image, Audio and PDF classes.
 
 > For a more in-depth walkthrough of the Image component, check out the [docs here](../concepts/multimodal.md)
 
-Instructor makes it easy to analyse and extract semantic information from images using OpenAI's GPT-4o models. [Click here](https://platform.openai.com/docs/models) to check if the model you'd like to use has vison capabilities.
+Instructor makes it easy to analyse and extract semantic information from images using OpenAI's GPT-4o models. [Click here](https://platform.openai.com/docs/models) to check if the model you'd like to use has vision capabilities.
 
 Let's see an example below with the sample image above where we'll load it in using our `from_url` method.
 

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -256,7 +256,7 @@ response = client.chat.completions.create(
                 # Option 1: Direct URL
                 PDF.from_url(url),
                 # Option 2: Local file
-                # PDF.from_file("path/to/local/invoice.pdf"),
+                # PDF.from_path("path/to/local/invoice.pdf"),
                 # Option 3: Base64 string
                 # PDF.from_base64("base64_encoded_string_here")
             ],

--- a/instructor/multimodal.py
+++ b/instructor/multimodal.py
@@ -509,6 +509,126 @@ class PDF(BaseModel):
         else:
             raise ValueError("PDF data is missing for base64 encoding.")
 
+    def to_anthropic(self) -> dict[str, Any]:
+        """Convert to Anthropic's document format."""
+        if (
+            isinstance(self.source, str)
+            and self.source.startswith(("http://", "https://"))
+            and not self.data
+        ):
+            return {
+                "type": "document",
+                "source": {
+                    "type": "url",
+                    "url": self.source,
+                },
+            }
+        else:
+            if not self.data:
+                self.data = requests.get(str(self.source)).content
+                self.data = base64.b64encode(self.data).decode("utf-8")
+
+            return {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": self.media_type,
+                    "data": self.data,
+                },
+            }
+
+    def to_genai(self):
+        from google.genai import types
+
+        if (
+            isinstance(self.source, str)
+            and self.source.startswith(("http://", "https://"))
+            and not self.data
+        ):
+            # Fetch the file from URL and convert to base64
+            data = requests.get(self.source).content
+            data = base64.b64encode(data).decode("utf-8")
+            return types.Part.from_bytes(
+                data=base64.b64decode(data),
+                mime_type=self.media_type,
+            )
+
+        if self.data:
+            return types.Part.from_bytes(
+                data=base64.b64decode(self.data),
+                mime_type=self.media_type,
+            )
+
+        raise ValueError("Unsupported PDF format")
+
+
+class PDFWithCacheControl(PDF):
+    """PDF with Anthropic prompt caching support."""
+
+    def to_anthropic(self) -> dict[str, Any]:
+        """Override Anthropic return with cache_control."""
+        result = super().to_anthropic()
+        result["cache_control"] = {"type": "ephemeral"}
+        return result
+
+
+class PDFWithGenaiFile(PDF):
+    @classmethod
+    def from_new_genai_file(
+        cls, file_path: str, retry_delay: int = 10, max_retries: int = 20
+    ) -> PDFWithGenaiFile:
+        """Create a new PDFWithGenaiFile from a file path."""
+        from google.genai.types import FileState
+        import time
+        from google.genai import Client
+
+        client = Client()
+        file = client.files.upload(file=file_path)
+        while file.state != FileState.ACTIVE:
+            time.sleep(retry_delay)
+            file = client.files.get(name=file.name)
+            if max_retries > 0:
+                max_retries -= 1
+            else:
+                raise Exception(
+                    "Max retries reached. File upload has been started but is still pending"
+                )
+
+        return cls(source=file.uri, media_type=file.mime_type, data=None)  # type: ignore
+
+    @classmethod
+    def from_existing_genai_file(cls, file_name: str) -> PDFWithGenaiFile:
+        """Create a new PDFWithGenaiFile from a file URL."""
+        from google.genai import types
+        from google.genai.types import FileState
+        from google.genai import Client
+
+        client = Client()
+        file = client.files.get(name=file_name)
+        if file.source == types.FileSource.UPLOADED and file.state == FileState.ACTIVE:
+            return cls(
+                source=file.uri,  # type: ignore
+                media_type=file.mime_type,  # type: ignore
+                data=None,
+            )
+        else:
+            raise ValueError("We only support uploaded PDFs for now")
+
+    def to_genai(self):
+        from google.genai import types
+
+        if (
+            self.source
+            and isinstance(self.source, str)
+            and "https://generativelanguage.googleapis.com/v1beta/files/" in self.source
+        ):
+            return types.Part.from_uri(
+                file_uri=self.source,
+                mime_type=self.media_type,
+            )
+
+        return super().to_genai()
+
 
 def convert_contents(
     contents: Union[  # noqa: UP007
@@ -652,6 +772,8 @@ def extract_genai_multimodal_content(
             if content_part.text and autodetect_images:
                 # Detect if the text is an image
                 converted_item = Image.autodetect_safely(content_part.text)
+
+                # We only do autodetection for images for now
                 if isinstance(converted_item, Image):
                     converted_contents.append(converted_item.to_genai())
                     continue

--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from instructor.multimodal import Image, Audio
+from instructor.multimodal import PDF, Image, Audio
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat import (
     ChatCompletion,
@@ -968,7 +968,7 @@ def convert_to_genai_messages(
                 for content_item in message["content"]:
                     if isinstance(content_item, str):
                         content_parts.append(types.Part.from_text(text=content_item))
-                    elif isinstance(content_item, (Image, Audio)):
+                    elif isinstance(content_item, (Image, Audio, PDF)):
                         content_parts.append(content_item.to_genai())
                     else:
                         raise ValueError(

--- a/tests/llm/test_genai/test_multimodal.py
+++ b/tests/llm/test_genai/test_multimodal.py
@@ -3,6 +3,7 @@ import pytest
 from pydantic import BaseModel
 import os
 from .util import models, modes
+import base64
 
 
 class ImageDescription(BaseModel):
@@ -13,6 +14,12 @@ curr_file = os.path.dirname(__file__)
 image_file = os.path.join(curr_file, "../../assets/image.jpg")
 audio_file = os.path.join(curr_file, "../../assets/gettysburg.wav")
 audio_url = "https://raw.githubusercontent.com/instructor-ai/instructor/main/tests/assets/gettysburg.wav"
+
+pdf_path = os.path.join(curr_file, "../../assets/invoice.pdf")
+
+
+pdf_base64 = base64.b64encode(open(pdf_path, "rb").read()).decode("utf-8")
+pdf_base64_string = f"data:application/pdf;base64,{pdf_base64}"
 
 
 long_message = """
@@ -227,3 +234,103 @@ async def test_autodetect_images_async(client, model, mode, autodetect_images):
     )
 
     assert autodetect_images == response
+
+
+class Invoice(BaseModel):
+    total: float
+    items: list[str]
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("pdf_source", [pdf_path, pdf_base64_string])
+def test_local_pdf(client, model, mode, pdf_source):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDF.autodetect(pdf_source),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+def test_existing_genai_file_pdf_integration(client, model, mode):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.from_new_genai_file(
+                        pdf_path
+                    ),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+def test_upload_file_genai_pdf_integration(client, model, mode):
+    client = instructor.from_genai(client, mode=mode)
+    file = client.files.upload(file=pdf_path)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.from_existing_genai_file(
+                        file.name
+                    ),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("mode", modes)
+@pytest.mark.parametrize("pdf_source", [pdf_path, pdf_base64_string])
+def test_local_pdf_with_genai_file(client, model, mode, pdf_source):
+    client = instructor.from_genai(client, mode=mode)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    "How much is the invoice?",
+                    instructor.multimodal.PDFWithGenaiFile.autodetect(pdf_source),
+                ],
+            }
+        ],
+        response_model=Invoice,
+    )
+    assert isinstance(response, Invoice)
+    assert response.total == 220
+    assert len(response.items) == 2


### PR DESCRIPTION
This adds support for OpenAI PDF support
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds OpenAI PDF support in `multimodal.py`, updates documentation, and adds tests for PDF handling.
> 
>   - **Behavior**:
>     - Adds support for OpenAI PDF handling in `multimodal.py`, including methods `autodetect`, `from_base64`, `from_path`, `from_raw_base64`, and `from_url` in `PDF` class.
>     - Implements `to_openai()` in `PDF` class to convert PDF data to OpenAI's document format.
>   - **Documentation**:
>     - Updates `multimodal.md` and `openai.md` to include examples and usage instructions for PDF handling.
>   - **Tests**:
>     - Adds `test_multimodal_pdf_file` in `test_multimodal.py` to test PDF handling with different sources (URL, path, base64).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for c6328dc8023abbbce988c7233bc479a03d6f1360. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->