### PR TITLE
fix(google-genai): Add more helpful error messages

### DIFF
--- a/instructor/utils.py
+++ b/instructor/utils.py
@@ -915,6 +915,16 @@ def extract_genai_system_message(
                         if isinstance(item, str):
                             system_messages += item + "\n\n"
 
+    if system_messages and len(messages) == 1:
+        raise ValueError(
+            "At least one user message must be included. A system message alone is not sufficient."
+        )
+
+    if re.search(r"{{.*?}}|{%.*?%}", system_messages):
+        raise ValueError(
+            "Jinja templating is not supported in system messages with Google GenAI, only user messages."
+        )
+
     return system_messages
 
 


### PR DESCRIPTION
## More helpful Google-GenAI error messages

I ran into a really annoying bug where there is currently nothing in place to catch the error so the error that eventually does come up isn't helpful to the user at all.

There are a few issues at play here and I've added in error messages that catch them, however, this may not be the long term solution.

### The Issues

1. When you are using Google GenAI and you send a list of messages where you only have a system message and no user messages. 
2. Currently there is support in instructor for being able to to apply templating to the system message with OpenAI however, this isn't currently possible with Google GenAI, but there is no warning that tells you this, so the user ends up just sending a request with the template placeholders never being replaced.

### Reproduction

#### Issue 1
```python
import os

from google import genai
from pydantic import BaseModel

import instructor

client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
client = instructor.from_genai(client, mode=instructor.Mode.GENAI_TOOLS)


class User(BaseModel):
    name: str
    id: int


name = "Randy"
uid = 12345

response = client.chat.completions.create(
    model="gemini-2.0-flash-lite",
    messages=[
        {
            "role": "system",
            "content": "{{ prompt }} This is {{ name }} with id {{ uid }}",
        },
    ],
    context={
        "prompt": "Extract the information from the following text:",
        "name": name,
        "uid": uid,
    },
    response_model=User,
)

print(response)
```
Which returns:
```
Traceback (most recent call last):
  File "/Users/stepheniezzi/Projects/open_source/instructor/local_testing/main.py", line 151, in <module>
    response = client.chat.completions.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stepheniezzi/Projects/open_source/instructor/instructor/client.py", line 180, in create
    return self.create_fn(
           ^^^^^^^^^^^^^^^
  File "/Users/stepheniezzi/Projects/open_source/instructor/instructor/patch.py", line 193, in new_create_sync
    response = retry_sync(
               ^^^^^^^^^^^
  File "/Users/stepheniezzi/Projects/open_source/instructor/instructor/retry.py", line 159, in retry_sync
    stream = kwargs.get("stream", False)
             ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

#### Issue 2
For the above reproduction, if you were to add a user message to the list of messages then you will not run into the above error, however, that's when you would encounter issue 2 where the request would go through successfully and silently fail because the templating would never be applied because the placeholders exist in the system message and not the user messages.

### Solution
I wasn't sure of the exact way you all would want to address the issues as I'd imagine eventually you would want to support templating the system messages for Google GenAI and there's a few ways to go about that. For now I'm proposing the simplest solution just so users are aware in the meantime.

### Details for Further Exploration
The stack trace is:
retry_sync (retry.py)
new_create_sync (patch.py) *also applies to async in the same way*
create (client.py)

Essentially what happens is that in `new_create_sync` the response model is handled which calls the client specific stuff like `handle_genai_tools` where first the system message is extracted and then the rest of the messages are handled later. But because there are no more messages once you get to `handle_templating` in `new_create_sync` it ends up returning None because the messages list is empty and that results in `new_kwargs` being sent to None and then the user gets the error in the reproduction above.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error handling in `extract_genai_system_message` for Google GenAI by raising specific `ValueError` for unsupported cases.
> 
>   - **Error Handling**:
>     - In `extract_genai_system_message` in `utils.py`, raises `ValueError` if only a system message is provided without user messages.
>     - Raises `ValueError` if Jinja templating is detected in system messages for Google GenAI.
>   - **Behavior**:
>     - Improves error messages for Google GenAI users by catching specific cases that previously led to unhelpful errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for d286785c13e5723a8f4ebdb7d5b06365af4d94cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->