### PR TITLE
Fix: simple test failure

### DIFF
--- a/instructor/dsl/simple_type.py
+++ b/instructor/dsl/simple_type.py
@@ -41,6 +41,16 @@ def validateIsSubClass(response_model: type):
         if len(typing.get_args(response_model)) == 0:
             return False
         return issubclass(typing.get_args(response_model)[0], BaseModel)
+
+    try:
+        # Add a guard here to prevent issues with GenericAlias
+        import types
+
+        if isinstance(response_model, types.GenericAlias):
+            return False
+    except Exception:
+        pass
+
     return issubclass(response_model, BaseModel)
 
 

--- a/tests/dsl/test_simple_type_fix.py
+++ b/tests/dsl/test_simple_type_fix.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
-from typing import Union, List
-
+from typing import Union, List  # noqa: UP035
+from typing import get_origin, get_args
 from instructor.dsl.simple_type import is_simple_type
 
 
@@ -9,17 +9,19 @@ class TestSimpleTypeFix(unittest.TestCase):
     def test_list_with_union_type(self):
         """Test that list[int | str] is correctly identified as a simple type."""
         # This is the type that was failing in Python 3.10
+        if sys.version_info < (3, 10):
+            self.skipTest("Union pipe syntax is only available in Python 3.10+")
         response_model = list[int | str]
-        self.assertTrue(is_simple_type(response_model), 
-                       f"list[int | str] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}")
+        self.assertTrue(
+            is_simple_type(response_model),
+            f"list[int | str] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}. Instead it was identified as {type(response_model)} with origin {get_origin(response_model)} and args {get_args(response_model)}",
+        )
 
     def test_list_with_union_type_alternative_syntax(self):
         """Test that List[Union[int, str]] is correctly identified as a simple type."""
         # Alternative syntax
-        response_model = List[Union[int, str]]
-        self.assertTrue(is_simple_type(response_model),
-                       f"List[Union[int, str]] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        response_model = List[Union[int, str]]  # noqa: UP006
+        self.assertTrue(
+            is_simple_type(response_model),
+            f"List[Union[int, str]] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}",
+        )

--- a/tests/test_fizzbuzz_fix.py
+++ b/tests/test_fizzbuzz_fix.py
@@ -6,17 +6,24 @@ from instructor.process_response import prepare_response_model
 
 class TestFizzbuzzFix(unittest.TestCase):
     def test_fizzbuzz_response_model(self):
+        if sys.version_info < (3, 10):
+            self.skipTest("Union pipe syntax is only available in Python 3.10+")
         """Test that list[int | str] works correctly as a response model."""
         # This is the type used in the fizzbuzz example
         response_model = list[int | str]
-        
+
         # First check that it's correctly identified as a simple type
-        self.assertTrue(is_simple_type(response_model), 
-                       f"list[int | str] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}")
-        
+        self.assertTrue(
+            is_simple_type(response_model),
+            f"list[int | str] should be a simple type in Python {sys.version_info.major}.{sys.version_info.minor}",
+        )
+
         # Then check that prepare_response_model handles it correctly
         prepared_model = prepare_response_model(response_model)
-        self.assertIsNotNone(prepared_model, "prepare_response_model should not return None for list[int | str]")
+        self.assertIsNotNone(
+            prepared_model,
+            "prepare_response_model should not return None for list[int | str]",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix test failure by adding guard for `GenericAlias` in `validateIsSubClass` and updating tests for Python 3.10 compatibility.
> 
>   - **Behavior**:
>     - Add guard in `validateIsSubClass` in `simple_type.py` to handle `GenericAlias` and prevent issues.
>   - **Tests**:
>     - Update `test_list_with_union_type` in `test_simple_type_fix.py` to skip for Python < 3.10 and improve assertion messages.
>     - Update `test_fizzbuzz_response_model` in `test_fizzbuzz_fix.py` to skip for Python < 3.10 and improve assertion messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=instructor-ai%2Finstructor&utm_source=github&utm_medium=referral)<sup> for 1855125850de81b8b8f8be2b80b60cb6e1800703. You can [customize](https://app.ellipsis.dev/instructor-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->